### PR TITLE
casting ID of non-file image as str for export

### DIFF
--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -168,7 +168,7 @@ class TransferControl(GraphControl):
                 if dtype == "Annotation":
                     id = "File" + id
                 if rel_path == "pixel_images":
-                    filepath = str(Path(subfolder) / (clean_id + ".tiff"))
+                    filepath = str(Path(subfolder) / (str(clean_id) + ".tiff"))
                     cli.invoke(['export', '--file', filepath, id])
                     downloaded_ids.append(id)
                 else:


### PR DESCRIPTION
Minor bug that went through: for images without underlying files, the filename building for exporting was not casting the ID number as a `str`, causing an exception. This should fix it.