### PR TITLE
fixes imports that autogenerate annotations

### DIFF
--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -401,8 +401,6 @@ class TransferControl(GraphControl):
                         is_annotated = True
                 if not is_annotated:
                     image_ids.append(img_id)
-            
-
         return image_ids
 
     def _make_image_map(self, source_map, dest_map):

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -392,6 +392,16 @@ class TransferControl(GraphControl):
             anns = ezomero.get_map_annotation_ids(conn, "Image", img_id)
             if not anns:
                 image_ids.append(img_id)
+            else:
+                is_annotated = False
+                for ann in anns:
+                    ann_content = conn.getObject("MapAnnotation", ann)
+                    if ann_content.getNs() == \
+                            'openmicroscopy.org/cli/transfer':
+                        is_annotated = True
+                if not is_annotated:
+                    image_ids.append(img_id)
+            
 
         return image_ids
 


### PR DESCRIPTION
This fixes the problem reported [here](https://forum.image.sc/t/errors-encountered-using-omero-cli-transfer/69852/7). Some images generate MapAnnotations on import time, and transfer was relying on just-imported images to have no annotations to detect which images required moving/annotating. We now check to see if the image has no annotation with namespace `'openmicroscopy.org/cli/transfer'`.