### PR TITLE
Fix formatting of <object> etc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dependency ever imagined". Try at your own risk.
 
 Creates a transfer packet for moving objects between OMERO server instances.
 
-The syntax for specifying objects is: <object>:<id> where <object> can be Image, Project or Dataset. Project is assumed if <object>: is omitted. A file path needs to be provided; a tar file with the contents of the packet will be created at the specified path.
+The syntax for specifying objects is: `<object>:<id>` where `<object>` can be `Image`, `Project` or `Dataset`. `Project` is assumed if `<object>:` is omitted. A file path needs to be provided; a tar file with the contents of the packet will be created at the specified path.
 
 Currently, only MapAnnotations, Tags, FileAnnotations and CommentAnnotations are packaged into the transfer pack, and only Point, Line, Ellipse, Rectangle and Polygon-type ROIs are packaged.
 


### PR DESCRIPTION
The `<object>` tags are not visible on https://github.com/ome/omero-cli-transfer/blob/main/README.md
it appears like:

The syntax for specifying objects is: : where can be Image, Project or Dataset. Project is assumed if : is omitted

To test, see https://github.com/will-moore/omero-cli-transfer/tree/readme_fixes