### PR TITLE
Better tests, fixing "dataset to plate" issue and ROI fill/strokecolors

### DIFF
--- a/.omero/docker-compose.yml
+++ b/.omero/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - CONFIG_omero_db_pass=${POSTGRES_PASSWORD}
       - CONFIG_omero_upgrades_url=
       - CONFIG_Ice_IPv6=0
+      - CONFIG_omero_policy_binary__access=+read,+write,+image,+plate
     ports:
       - "${OMERO_SERVER_TCP}4063"
       - "${OMERO_SERVER_SSL}4064"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Of course, this CAN be an issue, especially given `omero-py` _officially_ only s
 it is possible to run `omero-py` in Python 3.7 or newer as well. Our recommended way to do so it using `conda`.
 With conda installed, you can do
 ```
-conda create -n myenv -c ome python=3.7 zeroc-ice36-python
+conda create -n myenv -c conda-force python=3.7 zeroc-ice==3.6.5
 conda activate myenv
 pip install omero-cli-transfer
 ```
@@ -32,9 +32,11 @@ dependency ever imagined". Try at your own risk.
 
 Creates a transfer packet for moving objects between OMERO server instances.
 
-The syntax for specifying objects is: `<object>:<id>` where `<object>` can be `Image`, `Project` or `Dataset`. `Project` is assumed if `<object>:` is omitted. A file path needs to be provided; a tar file with the contents of the packet will be created at the specified path.
+The syntax for specifying objects is: `<object>:<id>` where `<object>` can be `Image`, `Project`, `Dataset`, `Plate` or `Screen`. `Project` is assumed if `<object>:` is omitted. A file path needs to be provided; a tar file with the contents of the packet will be created at the specified path.
 
-Currently, only MapAnnotations, Tags, FileAnnotations and CommentAnnotations are packaged into the transfer pack, and only Point, Line, Ellipse, Rectangle and Polygon-type ROIs are packaged.
+Currently, only MapAnnotations, Tags, FileAnnotations and CommentAnnotations are packaged into the transfer pack. All kinds of ROI should work.
+
+Note that, if you are packing a `Plate` or `Screen`, default OMERO settings prevent you from downloading Plates and you will generate an empty pack file if you do so. If you want to generate a pack file from these entities, you will need to set `omero.policy.binary_access` appropriately.
 
 `--zip` packs the object into a compressed zip file rather than a tarball.
 
@@ -50,7 +52,7 @@ omero transfer pack 999 tarfile.tar  # equivalent to Project:999
 
 ## `omero transfer unpack`
 
-Unpacks an existing transfer packet, imports images as orphans and uses the XML contained in the transfer packet to re-create links, annotations and ROIs.
+Unpacks an existing transfer packet, imports images/plates as orphans and uses the XML contained in the transfer packet to re-create links, annotations and ROIs.
 
 `--ln_s` forces imports to use the transfer=ln_s option, in-place importing files. Same restrictions of regular in-place imports apply.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ezomero>=1.0.1
-ome-types>=0.2.10
+ezomero>=1.2.1
+ome-types>=0.3.2
 setuptools>=58.0.0

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -137,7 +137,7 @@ def create_original_file(ann: FileAnnotation, ans: List[Annotation],
 
 
 def create_plate_map(ome: OME, conn: BlitzGateway) -> Tuple[dict, OME]:
-
+    print(ome.to_xml())
     newome = copy.deepcopy(ome)
     plate_map = {}
     map_ref_ids = []

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -1,19 +1,19 @@
 import ezomero
 from typing import List, Tuple
-from omero.model import DatasetI, IObject
+from omero.model import DatasetI, IObject, PlateI, WellI, WellSampleI, ImageI
 from omero.gateway import DatasetWrapper
 from ome_types.model import TagAnnotation, MapAnnotation, FileAnnotation, ROI
 from ome_types.model import CommentAnnotation, LongAnnotation, Annotation
 from ome_types.model import Line, Point, Rectangle, Ellipse, Polygon, Shape
 from ome_types.model import Polyline, Label, Project, Screen, Dataset, OME
-from ome_types.model import Image
+from ome_types.model import Image, Plate
 from ome_types.model.simple_types import Marker
 from omero.gateway import TagAnnotationWrapper, MapAnnotationWrapper
 from omero.gateway import CommentAnnotationWrapper, LongAnnotationWrapper
 from omero.gateway import FileAnnotationWrapper, OriginalFileWrapper
 from omero.sys import Parameters
 from omero.gateway import BlitzGateway
-from omero.rtypes import rstring
+from omero.rtypes import rstring, RStringI, rint
 from ezomero import rois
 from pathlib import Path
 import os
@@ -136,8 +136,8 @@ def create_original_file(ann: FileAnnotation, ans: List[Annotation],
     return ofile
 
 
-def create_plate_map(ome: OME, conn: BlitzGateway) -> Tuple[dict, OME]:
-    print(ome.to_xml())
+def create_plate_map(ome: OME, img_map: dict, conn: BlitzGateway
+                     ) -> Tuple[dict, OME]:
     newome = copy.deepcopy(ome)
     plate_map = {}
     map_ref_ids = []
@@ -167,13 +167,63 @@ def create_plate_map(ome: OME, conn: BlitzGateway) -> Tuple[dict, OME]:
             params,
             conn.SERVICE_OPTS
             )
-        plate_id = results[0][0].val
+
+        if results:
+            # plate was imported as plate
+            plate_id = results[0][0].val
+        else:
+            # plate was imported as images
+            plate_id = create_plate_from_images(plate, img_map, conn)
         plate_map[plate.id] = plate_id
     for p in newome.plates:
         for ref in p.annotation_ref:
             if ref.id in map_ref_ids:
                 p.annotation_ref.remove(ref)
     return plate_map, newome
+
+
+def create_plate_from_images(plate: Plate, img_map: dict, conn: BlitzGateway
+                             ) -> int:
+    plateobj = PlateI()
+    plateobj.name = RStringI(plate.name)
+    plateobj = conn.getUpdateService().saveAndReturnObject(plateobj)
+    plate_id = plateobj.getId().getValue()
+    for well in plate.wells:
+        img_ids = []
+        for ws in well.well_samples:
+            if ws.image_ref:
+                for imgref in ws.image_ref:
+                    img_ids.append(img_map[imgref[-1]])
+        add_image_to_plate(img_ids, plate_id, well.column,
+                           well.row, conn)
+    return plate_id
+
+
+def add_image_to_plate(image_ids: List[int], plate_id: int, column: int,
+                       row: int, conn: BlitzGateway) -> bool:
+    """
+    Add the Images to a Plate, creating a new well at the specified column and
+    row
+    NB - This will fail if there is already a well at that point
+    """
+    update_service = conn.getUpdateService()
+
+    well = WellI()
+    well.plate = PlateI(plate_id, False)
+    well.column = rint(column)
+    well.row = rint(row)
+
+    try:
+        for image_id in image_ids:
+            image = conn.getObject("Image", image_id)
+            ws = WellSampleI()
+            ws.image = ImageI(image.id, False)
+            ws.well = well
+            well.addWellSample(ws)
+        update_service.saveObject(well)
+    except Exception:
+        return False
+    return True
 
 
 def create_shapes(roi: ROI) -> List[Shape]:
@@ -398,7 +448,7 @@ def populate_omero(ome: OME, img_map: dict, conn: BlitzGateway, hash: str,
     proj_map = create_projects(ome.projects, conn)
     ds_map = create_datasets(ome.datasets, conn)
     screen_map = create_screens(ome.screens, conn)
-    plate_map, ome = create_plate_map(ome, conn)
+    plate_map, ome = create_plate_map(ome, img_map, conn)
     ann_map = create_annotations(ome.structured_annotations, conn,
                                  hash, folder, metadata)
     create_rois(ome.rois, ome.images, img_map, conn)

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -296,25 +296,24 @@ def create_rois(rois: List[ROI], imgs: List[Image], img_map: dict,
     for img in imgs:
         for roiref in img.roi_ref:
             roi = next(filter(lambda x: x.id == roiref.id, rois))
-            print(roi)
             shapes = create_shapes(roi)
-            print(roi.union[0].fill_color)
             if roi.union[0].fill_color:
                 fc = roi.union[0].fill_color.as_rgb_tuple()
                 if len(fc) == 3:
                     fill_color = fc + (0,)
                 else:
                     fill_color = fc
+            else:
+                fill_color = (0, 0, 0, 0)
             if roi.union[0].stroke_color:
                 sc = roi.union[0].stroke_color.as_rgb_tuple()
                 if len(sc) == 3:
                     stroke_color = sc + (0,)
                 else:
                     stroke_color = sc
+            else:
+                stroke_color = (0, 0, 0, 0)
             img_id_dest = img_map[img.id]
-            # using colors for the first shape
-            fill_color = _int_to_rgba(int(str(roi.union[0].fill_color)))
-            stroke_color = _int_to_rgba(int(str(roi.union[0].stroke_color)))
             ezomero.post_roi(conn, img_id_dest, shapes, name=roi.name,
                              description=roi.description,
                              fill_color=fill_color, stroke_color=stroke_color)

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -279,16 +279,16 @@ def create_shapes(roi: ROI) -> List[Shape]:
     return shapes
 
 
-# def _int_to_rgba(omero_val: int) -> Tuple[int, int, int, int]:
-#    """ Helper function returning the color as an Integer in RGBA encoding """
-#     if omero_val < 0:
-#         omero_val = omero_val + (2**32)
-#     r = omero_val >> 24
-#     g = omero_val - (r << 24) >> 16
-#     b = omero_val - (r << 24) - (g << 16) >> 8
-#     a = omero_val - (r << 24) - (g << 16) - (b << 8)
-#     # a = a / 256.0
-#     return (r, g, b, a)
+def _int_to_rgba(omero_val: int) -> Tuple[int, int, int, int]:
+    """ Helper function returning the color as an Integer in RGBA encoding """
+    if omero_val < 0:
+        omero_val = omero_val + (2**32)
+    r = omero_val >> 24
+    g = omero_val - (r << 24) >> 16
+    b = omero_val - (r << 24) - (g << 16) >> 8
+    a = omero_val - (r << 24) - (g << 16) - (b << 8)
+    # a = a / 256.0
+    return (r, g, b, a)
 
 
 def create_rois(rois: List[ROI], imgs: List[Image], img_map: dict,
@@ -313,8 +313,8 @@ def create_rois(rois: List[ROI], imgs: List[Image], img_map: dict,
                     stroke_color = sc
             img_id_dest = img_map[img.id]
             # using colors for the first shape
-            # fill_color = _int_to_rgba(int(str(roi.union[0].fill_color)))
-            # stroke_color = _int_to_rgba(int(str(roi.union[0].stroke_color)))
+            fill_color = _int_to_rgba(int(str(roi.union[0].fill_color)))
+            stroke_color = _int_to_rgba(int(str(roi.union[0].stroke_color)))
             ezomero.post_roi(conn, img_id_dest, shapes, name=roi.name,
                              description=roi.description,
                              fill_color=fill_color, stroke_color=stroke_color)

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -337,7 +337,6 @@ class TransferControl(GraphControl):
             ln_s = True
         else:
             ln_s = False
-        print(src_img_map, filelist)
         dest_img_map = self._import_files(folder, filelist,
                                           ln_s, args.skip, self.gateway)
         print("Matching source and destination images...")

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -312,3 +312,40 @@ class TestTransfer(CLITest):
         img, _ = ezomero.get_image(self.gw, im_ids[-1])
         assert img.getName() == 'combined_result.tiff'
         self.delete_all()
+
+    @pytest.mark.parametrize('target_name', sorted(SUPPORTED))
+    def test_pack_unpack(self, target_name, tmpdir):
+        if target_name == "datasetid" or target_name == "projectid" or\
+           target_name == "idonly" or target_name == "imageid":
+            self.create_image(target_name=target_name)
+        elif target_name == "plateid" or target_name == "screenid":
+            self.create_plate(target_name=target_name)
+        target = getattr(self, target_name)
+        args = self.args + ["pack", target, str(tmpdir / 'test.tar')]
+        self.cli.invoke(args, strict=True)
+        # run unpack
+        # asserts
+        self.delete_all()
+
+        if target_name == "datasetid" or target_name == "projectid" or\
+           target_name == "idonly" or target_name == "imageid":
+            self.create_image(target_name=target_name)
+        elif target_name == "plateid" or target_name == "screenid":
+            self.create_plate(target_name=target_name)
+        args = self.args + ["pack", target, "--zip", str(tmpdir / 'test.zip')]
+        self.cli.invoke(args, strict=True)
+        # run unpack
+        # asserts
+        self.delete_all()
+
+        args = self.args + ["pack", target, "--barchive",
+                            str(tmpdir / 'testba.tar')]
+        if target_name == "datasetid" or target_name == "projectid" \
+           or target_name == "idonly":
+            self.cli.invoke(args, strict=True)
+            # run unpack
+            # asserts
+        else:
+            with pytest.raises(ValueError):
+                self.cli.invoke(args, strict=True)
+        self.delete_all()

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -99,10 +99,9 @@ class TestTransfer(CLITest):
             self.gw.deleteObjects("Image", im_ids, deleteAnns=True,
                                   deleteChildren=True, wait=True)
 
-    def create_plate(self, sizec=4, sizez=1, sizet=1, target_name=None):
-        plates = self.import_plates(plates=2, client=self.client)
+    def create_plate(self, plates=2, target_name=None):
+        plates = self.import_plates(plates=plates, client=self.client)
         self.plateid = "Plate:%s" % plates[0].id.val
-        self.source = "Plate:%s" % plates[1].id.val
         screen = ezomero.post_screen(self.gw, "test_screen")
         self.screen = self.gw.getObject("Screen", screen)
         self.screenid = "Screen:%s" % self.screen.id
@@ -319,7 +318,7 @@ class TestTransfer(CLITest):
            target_name == "idonly" or target_name == "imageid":
             self.create_image(target_name=target_name)
         elif target_name == "plateid" or target_name == "screenid":
-            self.create_plate(target_name=target_name)
+            self.create_plate(plates=1, target_name=target_name)
         target = getattr(self, target_name)
         args = self.args + ["pack", target, str(tmpdir / 'test.tar')]
         self.cli.invoke(args, strict=True)
@@ -333,7 +332,7 @@ class TestTransfer(CLITest):
            target_name == "idonly" or target_name == "imageid":
             self.create_image(target_name=target_name)
         elif target_name == "plateid" or target_name == "screenid":
-            self.create_plate(target_name=target_name)
+            self.create_plate(plates=1, target_name=target_name)
         target = getattr(self, target_name)
         args = self.args + ["pack", target, "--zip", str(tmpdir / 'test.zip')]
         self.cli.invoke(args, strict=True)
@@ -383,7 +382,7 @@ class TestTransfer(CLITest):
             for p in scr.listChildren():
                 pl_id = p.getId()
                 count += 1
-            assert count == 2
+            assert count == 1
             pl = self.gw.getObject("Plate", pl_id)
             wells = pl.listChildren()
             count = 0


### PR DESCRIPTION
This PR includes:

- better tests, including a collection of tests that pack a target, unpack it and compare it to the original;
- a fix for #33 - plates that are imported as individual images are now collected into an actual plate
- a partial fix for #13 (again) - we're using the first `Shape` in an `ROI` to collect `fill_color` and `stroke_color`, and using `(0,0,0,0)` defaults in case these are not set