### PR TITLE
Roi and plate fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Creates a transfer packet for moving objects between OMERO server instances.
 
 The syntax for specifying objects is: `<object>:<id>` where `<object>` can be `Image`, `Project`, `Dataset`, `Plate` or `Screen`. `Project` is assumed if `<object>:` is omitted. A file path needs to be provided; a tar file with the contents of the packet will be created at the specified path.
 
-Currently, only MapAnnotations, Tags, FileAnnotations and CommentAnnotations are packaged into the transfer pack. All kinds of ROI should work.
+Currently, only MapAnnotations, Tags, FileAnnotations and CommentAnnotations are packaged into the transfer pack. All kinds of ROI (except Masks) should work.
 
 Note that, if you are packing a `Plate` or `Screen`, default OMERO settings prevent you from downloading Plates and you will generate an empty pack file if you do so. If you want to generate a pack file from these entities, you will need to set `omero.policy.binary_access` appropriately.
 
@@ -53,6 +53,8 @@ omero transfer pack 999 tarfile.tar  # equivalent to Project:999
 ## `omero transfer unpack`
 
 Unpacks an existing transfer packet, imports images/plates as orphans and uses the XML contained in the transfer packet to re-create links, annotations and ROIs.
+
+Note that `unpack` needs to be able to identify the images it imports inequivocally; this can be a problem in case you have other images with the same `clientPath` (i.e. that were imported from the exact same location, including filename) and no annotations created by omero-cli-transfer. The most common case to generate this issue is an `unpack` that fails after the import step - the lingering images are not annotated correctly and a retry of the same `unpack` will use the same `clientPath` and cause issues. The best solution is cleaning up after failed `unpack`s.
 
 `--ln_s` forces imports to use the transfer=ln_s option, in-place importing files. Same restrictions of regular in-place imports apply.
 

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -319,7 +319,6 @@ def create_rois(rois: List[ROI], imgs: List[Image], img_map: dict,
             else:
                 stroke_width = 1
             img_id_dest = img_map[img.id]
-            print(fill_color, stroke_color, stroke_width)
             ezomero.post_roi(conn, img_id_dest, shapes, name=roi.name,
                              description=roi.description,
                              fill_color=fill_color, stroke_color=stroke_color,

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -302,21 +302,28 @@ def create_rois(rois: List[ROI], imgs: List[Image], img_map: dict,
                 if len(fc) == 3:
                     fill_color = fc + (0,)
                 else:
-                    fill_color = fc
+                    alpha = fc[3] * 255
+                    fill_color = fc[0:3] + (int(alpha),)
             else:
                 fill_color = (0, 0, 0, 0)
             if roi.union[0].stroke_color:
                 sc = roi.union[0].stroke_color.as_rgb_tuple()
                 if len(sc) == 3:
-                    stroke_color = sc + (0,)
+                    stroke_color = sc + (255,)
                 else:
                     stroke_color = sc
             else:
                 stroke_color = (0, 0, 0, 0)
+            if roi.union[0].stroke_width:
+                stroke_width = int(roi.union[0].stroke_width)
+            else:
+                stroke_width = 1
             img_id_dest = img_map[img.id]
+            print(fill_color, stroke_color, stroke_width)
             ezomero.post_roi(conn, img_id_dest, shapes, name=roi.name,
                              description=roi.description,
-                             fill_color=fill_color, stroke_color=stroke_color)
+                             fill_color=fill_color, stroke_color=stroke_color,
+                             stroke_width=stroke_width)
     return
 
 

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -329,7 +329,7 @@ def create_rois(rois: List[ROI], imgs: List[Image], img_map: dict,
                 else:
                     stroke_color = sc
             else:
-                stroke_color = (0, 0, 0, 0)
+                stroke_color = (255, 255, 255, 255)
             if roi.union[0].stroke_width:
                 stroke_width = int(roi.union[0].stroke_width)
             else:

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -284,7 +284,7 @@ def create_label(shape: LabelI) -> Label:
     args = {'id': shape.getId().val, 'x': shape.getX().val,
             'y': shape.getY().val}
     args['text'] = shape.getTextValue().val
-    args['font_size'] = 50
+    args['font_size'] = 10
     args['the_c'] = 0
     args['the_z'] = 0
     args['the_t'] = 0

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -134,6 +134,8 @@ def create_point(shape: PointI) -> Point:
         args['locked'] = shape.getLocked().val
     if shape.getStrokeColor() is not None:
         args['stroke_color'] = shape.getStrokeColor().val
+    if shape.getStrokeWidth() is not None:
+        args['stroke_width'] = shape.getStrokeWidth().getValue()
     pt = Point(**args)
     return pt
 
@@ -160,6 +162,8 @@ def create_line(shape: LineI) -> Line:
         args['locked'] = shape.getLocked().val
     if shape.getStrokeColor() is not None:
         args['stroke_color'] = shape.getStrokeColor().val
+    if shape.getStrokeWidth() is not None:
+        args['stroke_width'] = shape.getStrokeWidth().getValue()
     if shape.getMarkerStart() is not None:
         args['marker_start'] = shape.getMarkerStart().val
     if shape.getMarkerEnd() is not None:
@@ -190,6 +194,8 @@ def create_rectangle(shape: RectangleI) -> Rectangle:
         args['locked'] = shape.getLocked().val
     if shape.getStrokeColor() is not None:
         args['stroke_color'] = shape.getStrokeColor().val
+    if shape.getStrokeWidth() is not None:
+        args['stroke_width'] = shape.getStrokeWidth().getValue()
     rec = Rectangle(**args)
     return rec
 
@@ -216,6 +222,8 @@ def create_ellipse(shape: EllipseI) -> Ellipse:
         args['locked'] = shape.getLocked().val
     if shape.getStrokeColor() is not None:
         args['stroke_color'] = shape.getStrokeColor().val
+    if shape.getStrokeWidth() is not None:
+        args['stroke_width'] = shape.getStrokeWidth().getValue()
     ell = Ellipse(**args)
     return ell
 
@@ -240,6 +248,8 @@ def create_polygon(shape: PolygonI) -> Polygon:
         args['locked'] = shape.getLocked().val
     if shape.getStrokeColor() is not None:
         args['stroke_color'] = shape.getStrokeColor().val
+    if shape.getStrokeWidth() is not None:
+        args['stroke_width'] = shape.getStrokeWidth().getValue()
     pol = Polygon(**args)
     return pol
 
@@ -264,6 +274,8 @@ def create_polyline(shape: PolylineI) -> Polyline:
         args['locked'] = shape.getLocked().val
     if shape.getStrokeColor() is not None:
         args['stroke_color'] = shape.getStrokeColor().val
+    if shape.getStrokeWidth() is not None:
+        args['stroke_width'] = shape.getStrokeWidth().getValue()
     pol = Polyline(**args)
     return pol
 
@@ -288,6 +300,8 @@ def create_label(shape: LabelI) -> Label:
         args['locked'] = shape.getLocked().val
     if shape.getStrokeColor() is not None:
         args['stroke_color'] = shape.getStrokeColor().val
+    if shape.getStrokeWidth() is not None:
+        args['stroke_width'] = shape.getStrokeWidth().getValue()
     pt = Label(**args)
     return pt
 

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -284,10 +284,12 @@ def create_label(shape: LabelI) -> Label:
     args = {'id': shape.getId().val, 'x': shape.getX().val,
             'y': shape.getY().val}
     args['text'] = shape.getTextValue().val
-    args['font_size'] = shape.getFontSize().getValue()
+    args['font_size'] = 50
     args['the_c'] = 0
     args['the_z'] = 0
     args['the_t'] = 0
+    if shape.getFontSize() is not None:
+        args['font_size'] = shape.getFontSize().getValue()
     if shape.getTheC() is not None:
         args['the_c'] = max(shape.getTheC().val, 0)
     if shape.getTheZ() is not None:

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -339,6 +339,7 @@ class TransferControl(GraphControl):
             ln_s = False
         dest_img_map = self._import_files(folder, filelist,
                                           ln_s, args.skip, self.gateway)
+        self._delete_all_rois(dest_img_map, self.gateway)
         print("Matching source and destination images...")
         img_map = self._make_image_map(src_img_map, dest_img_map)
         print("Creating and linking OMERO objects...")
@@ -426,6 +427,15 @@ class TransferControl(GraphControl):
             img_ids = self._get_image_ids(dest_path, gateway)
             dest_map[dest_path] = img_ids
         return dest_map
+
+    def _delete_all_rois(self, dest_map: dict, gateway: BlitzGateway):
+        roi_service = gateway.getRoiService()
+        for imgs in dest_map.values():
+            for img in imgs:
+                result = roi_service.findByImage(img, None)
+                for roi in result.rois:
+                    gateway.deleteObject(roi)
+        return
 
     def _get_image_ids(self, file_path: str, conn: BlitzGateway) -> List[str]:
         """Get the Ids of imported images.

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -178,7 +178,7 @@ class TransferControl(GraphControl):
         )
         unpack.add_argument(
             "--metadata",
-            choices=['all', 'none', 'img_id', 'timestamp',
+            choices=['all', 'none', 'img_id', 'plate_id', 'timestamp',
                      'software', 'version', 'md5', 'hostname', 'db_id',
                      'orig_user', 'orig_group'], nargs='+',
             help="Metadata field to be added to MapAnnotation"
@@ -261,7 +261,7 @@ class TransferControl(GraphControl):
             metadata = ['all']
         if "all" in metadata:
             metadata.remove("all")
-            metadata.extend(["img_id", "timestamp", "software",
+            metadata.extend(["img_id", "plate_id", "timestamp", "software",
                              "version", "hostname", "md5", "orig_user",
                              "orig_group"])
         if "none" in metadata:

--- a/test/unit/test_set.py
+++ b/test/unit/test_set.py
@@ -48,14 +48,14 @@ class TestPackSide():
         metadata = None
         self.transfer._process_metadata(metadata)
         assert set(self.transfer.metadata) == \
-            set(["img_id", "timestamp", "software", "version", "hostname",
-                 "md5", "orig_user", "orig_group"])
+            set(["img_id", "plate_id", "timestamp", "software", "version",
+                 "hostname", "md5", "orig_user", "orig_group"])
         self.transfer.metadata = []
         metadata = ['all', 'db_id']
         self.transfer._process_metadata(metadata)
         assert set(self.transfer.metadata) == \
-            set(["img_id", "timestamp", "software", "version", "hostname",
-                 "md5", "orig_user", "orig_group", "db_id"])
+            set(["img_id", "plate_id", "timestamp", "software", "version",
+                 "hostname", "md5", "orig_user", "orig_group", "db_id"])
         self.transfer.metadata = []
         metadata = ['none', 'db_id']
         self.transfer._process_metadata(metadata)


### PR DESCRIPTION
Included in this PR:
- multiple fixes for #13 (transferring colors and stroke width correctly, providing better defaults, deleting import-time ROIs to avoid ROI duplication);
- fix for #12 regarding Plates (Plates now use the same paradigm we had in Images, where unpacked objects get a map annotation and duplicate unpacks can find the newly-imported entities unambiguously);
- fix fo4r #39 (provides a sane default for font size in Labels if those are created without one; seems to be the same value (10) that iViewer uses for displaying these Labels).