### PR TITLE
RO-crate support

### DIFF
--- a/.omero/py-setup
+++ b/.omero/py-setup
@@ -12,7 +12,7 @@ wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.
 sh Miniconda3-latest-Linux-x86_64.sh -b -p /tmp/miniconda
 source /tmp/miniconda/bin/activate
 conda init
-conda create -n omero python=3.7
+conda create -n omero python=3.8
 conda activate omero
 conda install -c conda-forge zeroc-ice=3.6.5
 

--- a/README.md
+++ b/README.md
@@ -84,3 +84,9 @@ omero transfer unpack --folder /home/user/unpacked_folder/
     - a "comment" column if any Image has a `CommentAnnotation`;
     - a column per key in a `MapAnnotation` inside the pack, with an empty value for all images but the ones with a `MapAnnotation` with that key; for those images, it has the value for that annotation;
     - a final `original_omero_ids` column listing all OMERO IDs associated to that file in the origin server: for images, that is all `Image` IDs that use that file, and for file annotations that is all `Image` IDs that had that `FileAnnotation` attached to them.
+
+
+### RO-Crate export format
+
+- This requires an optional dependency on `ro-crate-py` that can be installed with `pip install omero-cli-transfer[rocrate]`.
+- Largely due to library limitations, current exports create a flat structure inside a zip file. For each image, `name` and `mimetype` are recorded. A `ro-crate-metadata.json` is added to the zip file.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # omero-cli-transfer
+
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7573592.svg)](https://doi.org/10.5281/zenodo.7573592)
+
+
 An OMERO CLI plugin for creating and using transfer packets between OMERO servers.
 
 Transfer packets contain objects and annotations. This project creates a zip file from an object 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ but that will require locally building a wheel for `zeroc-ice` (which pip does a
 process that can be anything from "completely seamless and without issues" to "I need to install every 
 dependency ever imagined". Try at your own risk.
 
+If you want optional RO-Crate exports, you can do 
+```
+pip install omero-cli-transfer[rocrate]
+```
+instead.
+
 # Usage
 
 ## `omero transfer pack`

--- a/setup.py
+++ b/setup.py
@@ -89,9 +89,12 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/TheJacksonLaboratory/omero-cli-transfer",
     install_requires=[
-        'ezomero',
-        'ome-types'
+        'ezomero==1.2.1',
+        'ome-types==0.3.3'
     ],
+    extras_require={
+        "rocrate": ["rocrate==0.7.0"],
+    },
     python_requires='>=3.7',
     cmdclass={'test': PyTest},
     tests_require=['pytest', 'restview', 'mox3'],

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     extras_require={
         "rocrate": ["rocrate==0.7.0"],
     },
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     cmdclass={'test': PyTest},
     tests_require=['pytest', 'restview', 'mox3'],
 )

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -316,7 +316,7 @@ def create_rois(rois: List[ROI], imgs: List[Image], img_map: dict,
             if roi.union[0].fill_color:
                 fc = roi.union[0].fill_color.as_rgb_tuple()
                 if len(fc) == 3:
-                    fill_color = fc + (0,)
+                    fill_color = fc + (255,)
                 else:
                     alpha = fc[3] * 255
                     fill_color = fc[0:3] + (int(alpha),)

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -755,21 +755,6 @@ def populate_rocrate(datatype: str, ome: OME, filepath: str,
         print("RO-Crate export of Plate/Screen currently unsupported")
         return
     rc = ROCrate()
-    # if datatype == "Project":
-    #     for proj in ome.projects:
-    #         datasets = []
-    #         os.makedirs(f"{folder}/{proj.name}")
-    #         proj_ds = list(rc.get_entities())[-1]
-    #         print(proj)
-    #         for ds_id in proj.dataset_ref:
-    #             ds = next(filter(lambda x: x.id == ds_id.id, ome.datasets))
-    #             proj_ds.add_dataset(None, ds.name, properties={
-    #                 "name": ds.name,
-    #                 "description": ds.description
-    #             })
-    #             datasets.append(ds.name)
-            
-    # print(rc.get_entities())
     files = path_id_dict.items()
     for id, file in files:
         img = next(filter(lambda x: x.id == id, ome.images))

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -741,6 +741,17 @@ def populate_tsv(datatype: str, ome: OME, filepath: str,
     return
 
 
+def populate_rocrate(datatype: str, ome: OME, filepath: str,
+                     path_id_dict: dict, folder: str):
+    if datatype == "Plate" or datatype == "Screen":
+        print("Bioimage Archive export of Plate/Screen currently unsupported")
+        return
+    with open(filepath, 'w') as fp:
+        write_lines(datatype, ome, fp, path_id_dict, folder)
+        fp.close()
+    return
+
+
 def generate_columns(ome: OME, ids: dict) -> List[str]:
     columns = ["filename"]
     if [v for v in ids.values() if v.startswith("file_annotations")]:

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -743,6 +743,14 @@ def populate_tsv(datatype: str, ome: OME, filepath: str,
 
 def populate_rocrate(datatype: str, ome: OME, filepath: str,
                      path_id_dict: dict, folder: str):
+    import importlib.util
+    if (importlib.util.find_spec('rocrate')):
+        from rocrate.rocrate import ROCrate
+    else:
+        raise ImportError("Could not import rocrate library. Make sure to "
+                          "install omero-cli-transfer with the optional "
+                          "[rocrate] addition")
+    rc = ROCrate()
     if datatype == "Plate" or datatype == "Screen":
         print("Bioimage Archive export of Plate/Screen currently unsupported")
         return

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -776,9 +776,9 @@ def populate_rocrate(datatype: str, ome: OME, filepath: str,
         format = mimetypes.MimeTypes().guess_type(file)[0]
         if not format:
             format = "image"
-        rc.add_file(file, properties={
+        rc.add_file(os.path.join(folder, file), properties={
                         "name": img.name,
-                        "encodingFormat": format                            
+                        "encodingFormat": format
                     })
     rc.write_zip(filepath)
     return

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -325,7 +325,7 @@ class TransferControl(GraphControl):
             populate_tsv(src_datatype, ome, md_fp,
                          path_id_dict, folder)
         if args.rocrate:
-            print(f"Creating RO-Crate metadta at {md_fp}.")
+            print(f"Creating RO-Crate metadata at {md_fp}.")
             populate_rocrate(src_datatype, ome, os.path.splitext(tar_path)[0],
                              path_id_dict, folder)
         else:

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -18,7 +18,7 @@ import hashlib
 from zipfile import ZipFile
 from typing import Callable, List, Any, Dict, Union, Optional, Tuple
 
-from generate_xml import populate_xml, populate_tsv
+from generate_xml import populate_xml, populate_tsv, populate_rocrate
 from generate_omero_objects import populate_omero
 
 import ezomero
@@ -151,6 +151,10 @@ class TransferControl(GraphControl):
                                    " Archive submission standards",
                 action="store_true")
         pack.add_argument(
+                "--rocrate", help="Pack into a file compliant with "
+                                  "RO-Crate standards",
+                action="store_true")
+        pack.add_argument(
             "--metadata",
             choices=['all', 'none', 'img_id', 'timestamp',
                      'software', 'version', 'md5', 'hostname', 'db_id',
@@ -276,6 +280,10 @@ class TransferControl(GraphControl):
             if args.barchive:
                 raise ValueError("Single image, plate or screen cannot be "
                                  "packaged for Bioimage Archive")
+        if isinstance(args.object, Plate) or isinstance(args.object, Screen):
+            if args.rocrate:
+                raise ValueError("Single image, plate or screen cannot be "
+                                 "packaged in a RO-Crate")
         if isinstance(args.object, Image):
             src_datatype, src_dataid = "Image", args.object.id
         elif isinstance(args.object, Dataset):
@@ -301,6 +309,8 @@ class TransferControl(GraphControl):
         os.makedirs(folder, mode=DIR_PERM, exist_ok=True)
         if args.barchive:
             md_fp = str(Path(folder) / "submission.tsv")
+        elif args.rocrate:
+            md_fp = str(Path(folder) / "ro-crate-metadata.json")
         else:
             md_fp = str(Path(folder) / "transfer.xml")
             print(f"Saving metadata at {md_fp}.")
@@ -314,6 +324,10 @@ class TransferControl(GraphControl):
             print(f"Creating Bioimage Archive TSV at {md_fp}.")
             populate_tsv(src_datatype, ome, md_fp,
                          path_id_dict, folder)
+        if args.rocrate:
+            print(f"Creating RO-Crate metadta at {md_fp}.")
+            populate_rocrate(src_datatype, ome, md_fp,
+                             path_id_dict, folder)
         self._package_files(os.path.splitext(tar_path)[0], args.zip, folder)
         print("Cleaning up...")
         shutil.rmtree(folder)

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -326,9 +326,11 @@ class TransferControl(GraphControl):
                          path_id_dict, folder)
         if args.rocrate:
             print(f"Creating RO-Crate metadta at {md_fp}.")
-            populate_rocrate(src_datatype, ome, md_fp,
+            populate_rocrate(src_datatype, ome, os.path.splitext(tar_path)[0],
                              path_id_dict, folder)
-        self._package_files(os.path.splitext(tar_path)[0], args.zip, folder)
+        else:
+            self._package_files(os.path.splitext(tar_path)[0], args.zip,
+                                folder)
         print("Cleaning up...")
         shutil.rmtree(folder)
         return


### PR DESCRIPTION
This PR covers #35 and the very last lingering effects of #13. It implements (rudimentary) RO-Crate exporting with an optional dependency and adds better defaults for `fillColor` on ROIs.