### PR TITLE
remove twine

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -17,13 +17,9 @@ jobs:
         python-version: 3.7
     - name: Install Tools
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Package and Upload
-      env:
-        VERSION: ${{ github.event.release.tag_name }}
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
+        python -mpip install wheel
         python setup.py sdist bdist_wheel
-        twine upload dist/* --verbose
+    - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.3.0
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/upload_to_test_pypi.yml
+++ b/.github/workflows/upload_to_test_pypi.yml
@@ -17,13 +17,10 @@ jobs:
         python-version: 3.7
     - name: Install Tools
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Package and Upload
-      env:
-        VERSION: ${{ github.event.release.tag_name }}
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      run: |
+        python -mpip install wheel
         python setup.py sdist bdist_wheel
-        twine upload --repository-url https://test.pypi.org/legacy/ dist/* --verbose
+    - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.3.0
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This proposed changes match the approach used in other Python repositories

no other Python repos use testpypi. This could be removed if we agree
Also I would suggest to use the common secret to push to pypi (commit not pushed). Any objections?