### PR TITLE
`prepare` can take a filelist instead of folder path

### DIFF
--- a/.omero/cli-build
+++ b/.omero/cli-build
@@ -22,5 +22,4 @@ conda activate omero
 
 export OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
 omero $PLUGIN -h
-export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
 python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -vs

--- a/.omero/cli-build
+++ b/.omero/cli-build
@@ -22,5 +22,5 @@ conda activate omero
 
 export OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
 omero $PLUGIN -h
-
+export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
 python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -vs

--- a/.omero/py-check
+++ b/.omero/py-check
@@ -6,7 +6,6 @@ set -u
 set -x
 
 TARGET=${TARGET:-..}
-
 cd $TARGET
 if [ -f .pre-commit-config.yaml ]; then
     pre-commit run -a

--- a/.omero/py-setup
+++ b/.omero/py-setup
@@ -23,7 +23,6 @@ conda install -c bioconda bftools
 
 cd $TARGET
 cd $(setup_dir)
-python setup.py sdist
-pip install -U dist/*.tar.gz
+pip install .
 python setup.py clean
 rm -rf dist *egg-info src/*egg-info

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ in that object, plus an XML file detailing the links between entities, annotatio
 The CLI plugin add the subcommand `transfer`, which in its turn has two further subcommands `omero transfer pack` and `omero transfer unpack`. Both subcommands (pack and unpack) will use an existing OMERO session created via CLI or prompt the user for parameters to create one.
 
 # Installation
-tl;dr: if you have `python>=3.7`, a simple `pip install omero-cli-transfer` _might_ do. We recommend conda, though.
+tl;dr: if you have `python>=3.8`, a simple `pip install omero-cli-transfer` _might_ do. We recommend conda, though.
 
-`omero-cli-transfer` requires at least Python 3.7. This is due to `ome-types` requiring that as well;
+`omero-cli-transfer` requires at least Python 3.8. This is due to `ome-types` requiring that as well;
 this package relies heavily on it, and it is not feasible without it. 
 
 Of course, this CAN be an issue, especially given `omero-py` _officially_ only supports Python 3.6. However,
-it is possible to run `omero-py` in Python 3.7 or newer as well. Our recommended way to do so it using `conda`.
+it is possible to run `omero-py` in Python 3.8 or newer as well. Our recommended way to do so it using `conda`.
 With conda installed, you can do
 ```
-conda create -n myenv -c conda-force python=3.7 zeroc-ice==3.6.5
+conda create -n myenv -c conda-force python=3.8 zeroc-ice==3.6.5
 conda activate myenv
 pip install omero-cli-transfer
 ```
-It is possible to do the same thing without `conda` as long as your python/pip version is at least 3.7,
+It is possible to do the same thing without `conda` as long as your python/pip version is at least 3.8,
 but that will require locally building a wheel for `zeroc-ice` (which pip does automatically) - it is a
 process that can be anything from "completely seamless and without issues" to "I need to install every 
 dependency ever imagined". Try at your own risk.

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -485,14 +485,14 @@ def create_objects(folder, filelist):
                 targets.append(img)
             if len(files) == 0:
                 targets.remove(img)
-        images = []
-        plates = []
-        annotations = []
-        counter_imgs = 1
-        counter_pls = 1
     else:
         with open(folder, "r") as f:
-            targets = f.readlines()
+            targets = f.read().splitlines()
+    images = []
+    plates = []
+    annotations = []
+    counter_imgs = 1
+    counter_pls = 1
     for target in targets:
         print(f"Processing file {target}\n")
         res = run_showinf(target, cli)

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -487,7 +487,11 @@ def create_objects(folder, filelist):
                 targets.remove(img)
     else:
         with open(folder, "r") as f:
-            targets = f.read().splitlines()
+            targets_str = f.read().splitlines()
+        targets = []
+        par_folder = Path(folder).parent
+        for target in targets_str:
+            targets.append(str((par_folder / target).resolve()))
     images = []
     plates = []
     annotations = []
@@ -867,7 +871,7 @@ def populate_xml_folder(folder: str, filelist: bool, conn: BlitzGateway,
     ome.plates = plates
     ome.structured_annotations = annotations
     if filelist:
-        filepath = str(Path.cwd() / "transfer.xml")
+        filepath = str(Path(folder).parent.resolve() / "transfer.xml")
     else:
         if Path(folder).exists():
             filepath = str(Path(folder) / "transfer.xml")

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -463,32 +463,36 @@ def create_provenance_metadata(conn: BlitzGateway, img_id: int,
     return kv, ref
 
 
-def create_objects(folder):
+def create_objects(folder, filelist):
     img_files = []
-    for path, subdirs, files in os.walk(folder):
-        for f in files:
-            img_files.append(os.path.abspath(os.path.join(path, f)))
-    targets = copy.deepcopy(img_files)
-    cli = CLI()
-    cli.loadplugins()
-    for img in img_files:
-        if img not in (targets):
-            continue
-        cmd = ["omero", 'import', '-f', img, "\n"]
-        res = cli.popen(cmd, stdout=PIPE, stderr=DEVNULL)
-        std = res.communicate()
-        files = parse_files_import(std[0].decode('UTF-8'))
-        if len(files) > 1:
+    if not filelist:
+        for path, subdirs, files in os.walk(folder):
             for f in files:
-                targets.remove(f)
-            targets.append(img)
-        if len(files) == 0:
-            targets.remove(img)
-    images = []
-    plates = []
-    annotations = []
-    counter_imgs = 1
-    counter_pls = 1
+                img_files.append(os.path.abspath(os.path.join(path, f)))
+        targets = copy.deepcopy(img_files)
+        cli = CLI()
+        cli.loadplugins()
+        for img in img_files:
+            if img not in (targets):
+                continue
+            cmd = ["omero", 'import', '-f', img, "\n"]
+            res = cli.popen(cmd, stdout=PIPE, stderr=DEVNULL)
+            std = res.communicate()
+            files = parse_files_import(std[0].decode('UTF-8'))
+            if len(files) > 1:
+                for f in files:
+                    targets.remove(f)
+                targets.append(img)
+            if len(files) == 0:
+                targets.remove(img)
+        images = []
+        plates = []
+        annotations = []
+        counter_imgs = 1
+        counter_pls = 1
+    else:
+        with open(folder, "r") as f:
+            targets = f.readlines()
     for target in targets:
         print(f"Processing file {target}\n")
         res = run_showinf(target, cli)
@@ -854,10 +858,10 @@ def populate_xml(datatype: str, id: int, filepath: str, conn: BlitzGateway,
     return ome, path_id_dict
 
 
-def populate_xml_folder(folder: str, conn: BlitzGateway, session: str
-                        ) -> Tuple[OME, dict]:
+def populate_xml_folder(folder: str, filelist: bool, conn: BlitzGateway,
+                        session: str) -> Tuple[OME, dict]:
     ome = OME()
-    images, plates, annotations = create_objects(folder)
+    images, plates, annotations = create_objects(folder, filelist)
     ome.images = images
     ome.plates = plates
     ome.structured_annotations = annotations

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -465,13 +465,13 @@ def create_provenance_metadata(conn: BlitzGateway, img_id: int,
 
 def create_objects(folder, filelist):
     img_files = []
+    cli = CLI()
+    cli.loadplugins()
     if not filelist:
         for path, subdirs, files in os.walk(folder):
             for f in files:
                 img_files.append(os.path.abspath(os.path.join(path, f)))
         targets = copy.deepcopy(img_files)
-        cli = CLI()
-        cli.loadplugins()
         for img in img_files:
             if img not in (targets):
                 continue
@@ -494,7 +494,8 @@ def create_objects(folder, filelist):
     counter_imgs = 1
     counter_pls = 1
     for target in targets:
-        print(f"Processing file {target}\n")
+        target = str(Path(target).absolute())
+        print(f"Processing file {target}")
         res = run_showinf(target, cli)
         imgs, pls, anns = parse_showinf(res,
                                         counter_imgs, counter_pls, target)
@@ -865,13 +866,16 @@ def populate_xml_folder(folder: str, filelist: bool, conn: BlitzGateway,
     ome.images = images
     ome.plates = plates
     ome.structured_annotations = annotations
-    filepath = str(Path(folder) / "transfer.xml")
-    if Path(folder).exists():
-        with open(filepath, 'w') as fp:
-            print(to_xml(ome), file=fp)
-            fp.close()
+    if filelist:
+        filepath = str(Path.cwd() / "transfer.xml")
     else:
-        raise ValueError("Folder cannot be found!")
+        if Path(folder).exists():
+            filepath = str(Path(folder) / "transfer.xml")
+        else:
+            raise ValueError("Folder cannot be found!")
+    with open(filepath, 'w') as fp:
+        print(to_xml(ome), file=fp)
+        fp.close()
     path_id_dict = list_file_ids(ome)
     return ome, path_id_dict
 

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -549,7 +549,8 @@ class TransferControl(GraphControl):
         return imgmap
 
     def __prepare(self, args):
-        populate_xml_folder(args.folder, self.gateway, self.session)
+        populate_xml_folder(args.folder, args.filelist, self.gateway,
+                            self.session)
         return
 
 

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -206,6 +206,9 @@ class TransferControl(GraphControl):
         )
         folder_help = ("Path to folder with image files")
         prepare.add_argument("folder", type=str, help=folder_help)
+        prepare.add_argument(
+            "--filelist", help="Pass path to a filelist rather than a folder",
+            action="store_true")
 
     @gateway_required
     def pack(self, args):

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -119,8 +119,14 @@ a folder that contains image files, rather than a source OMERO server. This
 is intended as a first step on a bulk-import workflow, followed by using
 `omero transfer unpack` to complete an import.
 
+--filelist allows you to specify a text file containing a list of file paths
+(one per line). The XML file will only take those files into consideration.
+The resulting `transfer.xml` file will be created on the current working
+directory.
+
 Examples:
 omero transfer prepare /home/user/folder_with_files
+omero transfer prepare --filelist /home/user/file_with_paths.txt
 """)
 
 

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -119,10 +119,17 @@ a folder that contains image files, rather than a source OMERO server. This
 is intended as a first step on a bulk-import workflow, followed by using
 `omero transfer unpack` to complete an import.
 
+Note: images imported from an XML generated with this tool will have whichever
+names `showinf` reports them to have; that is, the names on their internal
+metadata, which might be different from filenames. For multi-image files,
+image names follow the pattern "filename [imagename]", where 'imagename' is
+the one reported by `showinf`.
+
 --filelist allows you to specify a text file containing a list of file paths
-(one per line). The XML file will only take those files into consideration.
-The resulting `transfer.xml` file will be created on the current working
-directory.
+(one per line). Relative paths should be relative to the location of the file
+list. The XML file will only take those files into consideration.
+The resulting `transfer.xml` file will be created on the same directory of
+your file list.
 
 Examples:
 omero transfer prepare /home/user/folder_with_files

--- a/test/data/prepare/filelist.txt
+++ b/test/data/prepare/filelist.txt
@@ -1,0 +1,2 @@
+test_pyramid.ome.tif
+default-plate&plates=1.fake

--- a/test/data/prepare/transfer.xml
+++ b/test/data/prepare/transfer.xml
@@ -2,50 +2,32 @@
     <Plate ID="Plate:1" Name="Plate Name 0">
         <Well Column="0" ID="Well:0_0_0_0" Row="0" Color="255" ExternalDescription="External Description" ExternalIdentifier="External Identifier" Type="Transfection: done">
             <WellSample ID="WellSample:0_0_0_0_0_0" Index="0" PositionX="0.0" PositionY="1.0" Timepoint="2006-05-04T18:13:51">
-                <ImageRef ID="Image:1" />
+                <ImageRef ID="Image:2" />
             </WellSample>
         </Well>
-        <AnnotationRef ID="Annotation:-245185625979654701490316406351781182304" />
+        <AnnotationRef ID="Annotation:-166540319990038501817496698575818747072" />
     </Plate>
-    <Image ID="Image:1" Name="default-plate">
-        <Pixels DimensionOrder="XYZCT" ID="Pixels:1" SizeC="1" SizeT="1" SizeX="512" SizeY="512" SizeZ="1" Type="uint8">
+    <Image ID="Image:1" Name="test_pyramid.tiff">
+        <Pixels DimensionOrder="XYCZT" ID="Pixels:1" SizeC="1" SizeT="1" SizeX="16" SizeY="16" SizeZ="1" Type="uint8">
             <MetadataOnly />
         </Pixels>
-        <AnnotationRef ID="Annotation:-172939569407233550101909030829557976341" />
+        <AnnotationRef ID="Annotation:-86643574848290778120287886298910882783" />
     </Image>
-    <Image ID="Image:2" Name="test_pyramid.tiff">
-        <Pixels DimensionOrder="XYCZT" ID="Pixels:2" SizeC="1" SizeT="1" SizeX="16" SizeY="16" SizeZ="1" Type="uint8">
+    <Image ID="Image:2" Name="default-plate">
+        <Pixels DimensionOrder="XYZCT" ID="Pixels:2" SizeC="1" SizeT="1" SizeX="512" SizeY="512" SizeZ="1" Type="uint8">
             <MetadataOnly />
         </Pixels>
-        <AnnotationRef ID="Annotation:-324306227964107542000952667676993603912" />
-    </Image>
-    <Image ID="Image:3" Name="vsi-ets-test-jpg2k.vsi [001 C405, C488]">
-        <Pixels DimensionOrder="XYCZT" ID="Pixels:3" SizeC="2" SizeT="1" SizeX="1645" SizeY="1682" SizeZ="11" Type="uint16">
-            <MetadataOnly />
-        </Pixels>
-        <AnnotationRef ID="Annotation:-257696975305797818629314594066683015430" />
-    </Image>
-    <Image ID="Image:4" Name="vsi-ets-test-jpg2k.vsi [macro image]">
-        <Pixels DimensionOrder="XYCZT" ID="Pixels:4" SizeC="3" SizeT="1" SizeX="501" SizeY="512" SizeZ="1" Type="uint8">
-            <MetadataOnly />
-        </Pixels>
-        <AnnotationRef ID="Annotation:-145147221356188951573746383297119544119" />
+        <AnnotationRef ID="Annotation:-134337008044623056588408027657468159176" />
     </Image>
     <StructuredAnnotations>
-        <CommentAnnotation ID="Annotation:-172939569407233550101909030829557976341" Namespace="Image:1">
-            <Value>/mnt/c/Users/erick/Documents/GitHub/omero-cli-transfer/test/data/prepare/default-plate&amp;plates=1.fake</Value>
-        </CommentAnnotation>
-        <CommentAnnotation ID="Annotation:-245185625979654701490316406351781182304" Namespace="Plate:1">
-            <Value>/mnt/c/Users/erick/Documents/GitHub/omero-cli-transfer/test/data/prepare/default-plate&amp;plates=1.fake</Value>
-        </CommentAnnotation>
-        <CommentAnnotation ID="Annotation:-324306227964107542000952667676993603912" Namespace="Image:2">
+        <CommentAnnotation ID="Annotation:-86643574848290778120287886298910882783" Namespace="Image:1">
             <Value>/mnt/c/Users/erick/Documents/GitHub/omero-cli-transfer/test/data/prepare/test_pyramid.ome.tif</Value>
         </CommentAnnotation>
-        <CommentAnnotation ID="Annotation:-257696975305797818629314594066683015430" Namespace="Image:3">
-            <Value>/mnt/c/Users/erick/Documents/GitHub/omero-cli-transfer/test/data/prepare/vsi-ets-test-jpg2k.vsi</Value>
+        <CommentAnnotation ID="Annotation:-134337008044623056588408027657468159176" Namespace="Image:2">
+            <Value>/mnt/c/Users/erick/Documents/GitHub/omero-cli-transfer/test/data/prepare/default-plate&amp;plates=1.fake</Value>
         </CommentAnnotation>
-        <CommentAnnotation ID="Annotation:-145147221356188951573746383297119544119" Namespace="Image:4">
-            <Value>/mnt/c/Users/erick/Documents/GitHub/omero-cli-transfer/test/data/prepare/vsi-ets-test-jpg2k.vsi</Value>
+        <CommentAnnotation ID="Annotation:-166540319990038501817496698575818747072" Namespace="Plate:1">
+            <Value>/mnt/c/Users/erick/Documents/GitHub/omero-cli-transfer/test/data/prepare/default-plate&amp;plates=1.fake</Value>
         </CommentAnnotation>
     </StructuredAnnotations>
 </OME>


### PR DESCRIPTION
This adds the optional `--filelist` argument to `omero transfer prepare` - when set, instead of passing the path to a folder that will generate an XML file, the user should pass a path to a text file containing a list of file paths (one per line). The generated XML will only include references to the files specified in the text file.