### PR TITLE
Fix typo in README.md (forge not force, and single =)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Of course, this CAN be an issue, especially given `omero-py` _officially_ only s
 it is possible to run `omero-py` in Python 3.8 or newer as well. Our recommended way to do so it using `conda`.
 With conda installed, you can do
 ```
-conda create -n myenv -c conda-forge python=3.8 zeroc-ice==3.6.5
+conda create -n myenv -c conda-forge python=3.8 zeroc-ice=3.6.5
 conda activate myenv
 pip install omero-cli-transfer
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Of course, this CAN be an issue, especially given `omero-py` _officially_ only s
 it is possible to run `omero-py` in Python 3.8 or newer as well. Our recommended way to do so it using `conda`.
 With conda installed, you can do
 ```
-conda create -n myenv -c conda-force python=3.8 zeroc-ice==3.6.5
+conda create -n myenv -c conda-forge python=3.8 zeroc-ice==3.6.5
 conda activate myenv
 pip install omero-cli-transfer
 ```


### PR DESCRIPTION
Just noticed the install instructions have a typo: `conda-force` instead of `conda-forge`
Also, conda uses single `=` to specify versions, not `==` see:
https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html#installing-packages
This is a quick fix, so copy-pasta works!

Edit: not sure what the spurious diff is for line 125, this was a quick edit using the GitHub web interface.