### PR TITLE
using relative paths for `--filelist` as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     packages=['', 'omero.plugins'],
     package_dir={"": "src"},
     name="omero-cli-transfer",
-    version='0.7.1',
+    version='0.7.2',
     maintainer="Erick Ratamero",
     maintainer_email="erick.ratamero@jax.org",
     description=("A set of utilities for exporting a transfer"

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -467,6 +467,7 @@ def create_objects(folder, filelist):
     img_files = []
     cli = CLI()
     cli.loadplugins()
+    par_folder = Path(folder).parent
     if not filelist:
         for path, subdirs, files in os.walk(folder):
             for f in files:
@@ -491,7 +492,6 @@ def create_objects(folder, filelist):
         with open(folder, "r") as f:
             targets_str = f.read().splitlines()
         targets = []
-        par_folder = Path(folder).parent
         for target in targets_str:
             targets.append(str((par_folder / target).resolve()))
     images = []
@@ -503,8 +503,8 @@ def create_objects(folder, filelist):
         target_full = os.path.join(os.getcwd(), folder, target)
         print(f"Processing file {target_full}")
         res = run_showinf(target_full, cli)
-        imgs, pls, anns = parse_showinf(res,
-                                        counter_imgs, counter_pls, target)
+        imgs, pls, anns = parse_showinf(res, counter_imgs, counter_pls,
+                                        target, par_folder)
         images.extend(imgs)
         counter_imgs = counter_imgs + len(imgs)
         plates.extend(pls)
@@ -532,7 +532,7 @@ def parse_files_import(text, folder):
     return clean_targets
 
 
-def parse_showinf(text, counter_imgs, counter_plates, target):
+def parse_showinf(text, counter_imgs, counter_plates, target, folder):
     ome = from_xml(text)
     images = []
     plates = []
@@ -552,9 +552,10 @@ def parse_showinf(text, counter_imgs, counter_plates, target):
             img = Image(id=img_id_str, name=image.name, pixels=pix)
         img_id += 1
         uid = (-1) * uuid4().int
+        rel_target = os.path.relpath(target, folder)
         an = CommentAnnotation(id=uid,
                                namespace=img_id_str,
-                               value=target
+                               value=rel_target
                                )
         annotations.append(an)
         anref = AnnotationRef(id=an.id)


### PR DESCRIPTION
`omero transfer prepare --filelist` now also uses relative paths for indicating image file locations in `transfer.xml`.