### PR TITLE
Human readable pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Note that, if you are packing a `Plate` or `Screen`, default OMERO settings prev
 files in a single folder). A JSON metadata file is added with basic information
 about the files (name, mimetype).
 
-`--simple` creates a "human-readable" package; one folder per project or dataset is created and image files are placed according to where they came from in the OMERO server. Note that a package generated with this option is NOT guaranteed to work with `unpack`.
+`--simple` creates a "human-readable" package; one folder per project or dataset is created and image files are placed according to where they came from in the OMERO server. Note that a package generated with this option is not guaranteed to work with `unpack`, though it often will.
 
 `--metadata` allows you to specify which transfer metadata will be saved in `transfer.xml` as possible MapAnnotation values to the images. Defaults to image ID, timestamp, software version, source hostname, md5, source username, source group. 
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Note that, if you are packing a `Plate` or `Screen`, default OMERO settings prev
 
 `--barchive` creates a package compliant with Bioimage Archive submission standards - see below for more detail.
 
+`--rocrate` generates a RO-Crate compliant package with flat structure (all image
+files in a single folder). A JSON metadata file is added with basic information
+about the files (name, mimetype).
+
+`--simple` creates a "human-readable" package; one folder per project or dataset is created and image files are placed according to where they came from in the OMERO server. Note that a package generated with this option is NOT guaranteed to work with `unpack`.
+
+`--metadata` allows you to specify which transfer metadata will be saved in `transfer.xml` as possible MapAnnotation values to the images. Defaults to image ID, timestamp, software version, source hostname, md5, source username, source group. 
+
 Examples:
 ```
 omero transfer pack Image:123 transfer_pack.tar
@@ -76,6 +84,8 @@ Note that unpack needs to be able to identify the images it imports inequivocall
 `--merge` will use existing Projects, Datasets and Screens if the current user
 already owns entities with the same name as ones defined in `transfer.xml`,
 effectively merging the "new" unpacked entities with existing ones.
+
+`--metadata` allows you to specify which transfer metadata will be used from `transfer.xml` as MapAnnotation values to the images. Fields that do not exist on `transfer.xml` will be ignored. Defaults to image ID, timestamp, software version, source hostname, md5, source username, source group. 
 
 Examples:
 ```

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     packages=['', 'omero.plugins'],
     package_dir={"": "src"},
     name="omero-cli-transfer",
-    version='0.7.3',
+    version='0.8.0',
     maintainer="Erick Ratamero",
     maintainer_email="erick.ratamero@jax.org",
     description=("A set of utilities for exporting a transfer"

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -738,13 +738,9 @@ def populate_image(obj: ImageI, ome: OME, conn: BlitzGateway, hostname: str,
 def populate_dataset(obj: DatasetI, ome: OME, conn: BlitzGateway,
                      hostname: str, metadata: List[str], simple: bool,
                      proj: Optional[str] = None,
-                     duplicate: Optional[bool] = False
                      ) -> DatasetRef:
     id = obj.getId()
-    if duplicate:
-        name = str(id) + "_" + obj.getName()
-    else:
-        name = obj.getName()
+    name = obj.getName()
     desc = obj.getDescription()
     ds, ds_ref = create_dataset_and_ref(id=id, name=name,
                                         description=desc)
@@ -770,18 +766,10 @@ def populate_project(obj: ProjectI, ome: OME, conn: BlitzGateway,
     proj, _ = create_proj_and_ref(id=id, name=name, description=desc)
     for ann in obj.listAnnotations():
         add_annotation(proj, ann, ome, conn)
-    ds_names = []
-    for ds in obj.listChildren():
-        ds_names.append(ds.getName())
-    duplicate_names = [x for x in ds_names if ds_names.count(x) > 1]
+    
     for ds in obj.listChildren():
         ds_obj = conn.getObject('Dataset', ds.getId())
-        if ds.getName() in duplicate_names:
-            ds_ref = populate_dataset(ds_obj, ome, conn, hostname, metadata,
-                                      simple, proj=str(id) + "_" + name,
-                                      duplicate=True)
-        else:
-            ds_ref = populate_dataset(ds_obj, ome, conn, hostname, metadata,
+        ds_ref = populate_dataset(ds_obj, ome, conn, hostname, metadata,
                                       simple, proj=str(id) + "_" + name)
 
         proj.dataset_refs.append(ds_ref)

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -766,11 +766,11 @@ def populate_project(obj: ProjectI, ome: OME, conn: BlitzGateway,
     proj, _ = create_proj_and_ref(id=id, name=name, description=desc)
     for ann in obj.listAnnotations():
         add_annotation(proj, ann, ome, conn)
-    
+
     for ds in obj.listChildren():
         ds_obj = conn.getObject('Dataset', ds.getId())
         ds_ref = populate_dataset(ds_obj, ome, conn, hostname, metadata,
-                                      simple, proj=str(id) + "_" + name)
+                                  simple, proj=str(id) + "_" + name)
 
         proj.dataset_refs.append(ds_ref)
     ome.projects.append(proj)

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -347,7 +347,7 @@ def create_shapes(roi: RoiI) -> List[Shape]:
 
 
 def create_filepath_annotations(id: str, conn: BlitzGateway,
-                                simple: bool, ome: OME,
+                                simple: bool,
                                 filename: Union[str, PathLike] = ".",
                                 plate_path: Optional[str] = None,
                                 ds: Optional[str] = None,
@@ -359,6 +359,10 @@ def create_filepath_annotations(id: str, conn: BlitzGateway,
     anrefs = []
     fp_type = ns.split(":")[0]
     clean_id = int(ns.split(":")[-1])
+    if not ds:
+        ds = ""
+    if not proj:
+        proj = ""
     if fp_type == "Image":
         fpaths = ezomero.get_original_filepaths(conn, clean_id)
         if len(fpaths) > 1:
@@ -704,7 +708,7 @@ def populate_image(obj: ImageI, ome: OME, conn: BlitzGateway, hostname: str,
         if ref:
             img.annotation_refs.append(ref)
     filepath_anns, refs = create_filepath_annotations(img_id, conn,
-                                                      simple, ome, ds=ds,
+                                                      simple, ds=ds,
                                                       proj=proj)
     for i in range(len(filepath_anns)):
         ome.structured_annotations.append(filepath_anns[i])
@@ -813,6 +817,7 @@ def populate_plate(obj: PlateI, ome: OME, conn: BlitzGateway,
                 int(ann.id.split(":")[-1]) < 0):
             plate_path = ann.value
     filepath_anns, refs = create_filepath_annotations(pl.id, conn,
+                                                      simple=False,
                                                       plate_path=plate_path)
     for i in range(len(filepath_anns)):
         ome.structured_annotations.append(filepath_anns[i])
@@ -903,6 +908,7 @@ def add_annotation(obj: Union[Project, Dataset, Image, Plate, Screen,
         filepath_anns, refs = create_filepath_annotations(
                                 f.id,
                                 conn,
+                                simple=False,
                                 filename=ann.getFile().getName())
         for i in range(len(filepath_anns)):
             ome.structured_annotations.append(filepath_anns[i])

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -377,7 +377,6 @@ class TransferControl(GraphControl):
             if args.simple:
                 raise ValueError("Single plate or screen cannot be "
                                  "packaged in human-readable format")
-        
         if isinstance(args.object, Image):
             src_datatype, src_dataid = "Image", args.object.id
         elif isinstance(args.object, Dataset):

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -148,6 +148,35 @@ class TestTransfer(CLITest):
                 self.cli.invoke(args, strict=True)
         self.delete_all()
 
+    @pytest.mark.parametrize('target_name', sorted(SUPPORTED))
+    def test_pack_special(self, target_name, tmpdir):
+        if target_name == "datasetid" or target_name == "projectid" or\
+           target_name == "idonly" or target_name == "imageid":
+            self.create_image(target_name=target_name)
+        elif target_name == "plateid" or target_name == "screenid":
+            self.create_plate(target_name=target_name)
+        target = getattr(self, target_name)
+        args = self.args + ["pack", target, "--barchive",
+                            str(tmpdir / 'testba.tar')]
+        if target_name == "datasetid" or target_name == "projectid" \
+           or target_name == "idonly":
+            self.cli.invoke(args, strict=True)
+            assert os.path.exists(str(tmpdir / 'testba.tar'))
+            assert os.path.getsize(str(tmpdir / 'testba.tar')) > 0
+        else:
+            with pytest.raises(ValueError):
+                self.cli.invoke(args, strict=True)
+        args = self.args + ["pack", target, "--simple",
+                            str(tmpdir / 'testsimple.tar')]
+        if target_name == "plateid" or target_name == "screenid":
+            with pytest.raises(ValueError):
+                self.cli.invoke(args, strict=True)
+        else:
+            self.cli.invoke(args, strict=True)
+            assert os.path.exists(str(tmpdir / 'testsimple.tar'))
+            assert os.path.getsize(str(tmpdir / 'testsimple.tar')) > 0
+        self.delete_all()
+
     @pytest.mark.parametrize('folder_name', TEST_FOLDERS)
     def test_unpack_folder(self, folder_name):
         self.args += ["unpack", "--folder", folder_name]

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -12,6 +12,7 @@ from omero.gateway import BlitzGateway
 import ezomero
 import pytest
 import os
+import tarfile
 
 SUPPORTED = [
     "idonly", "imageid", "datasetid", "projectid", "plateid", "screenid"]
@@ -175,6 +176,17 @@ class TestTransfer(CLITest):
             self.cli.invoke(args, strict=True)
             assert os.path.exists(str(tmpdir / 'testsimple.tar'))
             assert os.path.getsize(str(tmpdir / 'testsimple.tar')) > 0
+            f = tarfile.open(str(tmpdir / 'testsimple.tar'), "r")
+            print(f.getmembers())
+            if target_name == "datasetid":
+                # `./`, ds folder, 2 files, transfer.xml
+                assert len(f.getmembers()) == 5
+            elif target_name == "imageid":
+                # `./`, 1 file, transfer.xml
+                assert len(f.getmembers()) == 3
+            else:
+                # `./`, proj folder, ds folder, 2 files, transfer.xml
+                assert len(f.getmembers()) == 6
         self.delete_all()
 
     @pytest.mark.parametrize('folder_name', TEST_FOLDERS)

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -177,7 +177,6 @@ class TestTransfer(CLITest):
             assert os.path.exists(str(tmpdir / 'testsimple.tar'))
             assert os.path.getsize(str(tmpdir / 'testsimple.tar')) > 0
             f = tarfile.open(str(tmpdir / 'testsimple.tar'), "r")
-            print(f.getmembers())
             if target_name == "datasetid":
                 # `./`, ds folder, 2 files, transfer.xml
                 assert len(f.getmembers()) == 5


### PR DESCRIPTION
this adds the sub-option `--simple` to `omero transfer pack`, generating a human-readable export where projects and datasets are represented by folders with the "ID_NAME" format. 