### PR TITLE
Packing and unpacking figures

### DIFF
--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -930,7 +930,7 @@ def list_file_ids(ome: OME) -> dict:
 
 
 def populate_xml(datatype: str, id: int, filepath: str, conn: BlitzGateway,
-                 hostname: str, barchive: bool, simple: bool,
+                 hostname: str, barchive: bool, simple: bool, figure: bool,
                  metadata: List[str]) -> Tuple[OME, dict]:
     ome = OME()
     obj = conn.getObject(datatype, id)
@@ -948,6 +948,8 @@ def populate_xml(datatype: str, id: int, filepath: str, conn: BlitzGateway,
         with open(filepath, 'w') as fp:
             print(to_xml(ome), file=fp)
             fp.close()
+    if (not (barchive or simple)) and figure:
+        populate_figures(ome, conn)
     path_id_dict = list_file_ids(ome)
     return ome, path_id_dict
 
@@ -1009,6 +1011,10 @@ def populate_rocrate(datatype: str, ome: OME, filepath: str,
                         "encodingFormat": format
                     })
     rc.write_zip(filepath)
+    return
+
+
+def populate_figures(ome: OME, conn: BlitzGateway):
     return
 
 

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -446,6 +446,20 @@ def create_filepath_annotations(id: str, conn: BlitzGateway,
     return anns, anrefs
 
 
+def create_figure_annotations(id: str) -> Tuple[CommentAnnotation,
+                                                AnnotationRef]:
+    ns = id
+    clean_id = int(ns.split(":")[-1])
+    f = f'figures/Figure_{clean_id}.json'
+    uid = (-1) * uuid4().int
+    an = CommentAnnotation(id=uid,
+                           namespace=ns,
+                           value=f
+                           )
+    anref = AnnotationRef(id=an.id)
+    return (an, anref)
+
+
 def create_provenance_metadata(conn: BlitzGateway, img_id: int,
                                hostname: str,
                                metadata: Union[List[str], None], plate: bool
@@ -1061,6 +1075,9 @@ def populate_figures(ome: OME, conn: BlitzGateway, filepath: str):
             f, _ = create_file_ann_and_ref(id=fig_obj.getId(),
                                            namespace=fig_obj.getNs(),
                                            binary_file=binaryfile)
+            filepath_ann, ref = create_figure_annotations(f.id)
+            ome.structured_annotations.append(filepath_ann)
+            f.annotation_ref.append(ref)
             ome.structured_annotations.append(f)
         else:
             os.remove(filepath)

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -477,7 +477,7 @@ class TransferControl(GraphControl):
         img_map = self._make_image_map(src_img_map, dest_img_map, self.gateway)
         print("Creating and linking OMERO objects...")
         populate_omero(ome, img_map, self.gateway,
-                       hash, folder, self.metadata, args.merge)
+                       hash, folder, self.metadata, args.merge, args.figure)
         return
 
     def _load_from_pack(self, filepath: str, output: Optional[str] = None

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -62,6 +62,9 @@ are packaged into the transfer pack, and only Point, Line, Ellipse, Rectangle
 and Polygon-type ROIs are packaged.
 
 --zip packs the object into a compressed zip file rather than a tarball.
+             
+--figure includes OMERO.Figures; note that this can lead to a performance
+hit and that Figures can reference images that are not included in your pack!
 
 --barchive creates a package compliant with Bioimage Archive submission
 standards - see repo README for more detail. This package format is not
@@ -108,6 +111,11 @@ a single file.
 --merge will use existing Projects, Datasets and Screens if the current user
 already owns entities with the same name as ones defined in `transfer.xml`,
 effectively merging the "new" unpacked entities with existing ones.
+               
+--figure unpacks and updates Figures, if your pack contains those. Note that
+there's no guaranteed behavior for images referenced on Figures that were not
+included in a pack. You can just have an image missing, a completely unrelated
+image, a permission error. Use at your own risk!
 
 --metadata allows you to specify which transfer metadata will be used from
 `transfer.xml` as MapAnnotation values to the images. Fields that do not

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -62,7 +62,7 @@ are packaged into the transfer pack, and only Point, Line, Ellipse, Rectangle
 and Polygon-type ROIs are packaged.
 
 --zip packs the object into a compressed zip file rather than a tarball.
-             
+
 --figure includes OMERO.Figures; note that this can lead to a performance
 hit and that Figures can reference images that are not included in your pack!
 

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -111,7 +111,7 @@ a single file.
 --merge will use existing Projects, Datasets and Screens if the current user
 already owns entities with the same name as ones defined in `transfer.xml`,
 effectively merging the "new" unpacked entities with existing ones.
-               
+
 --figure unpacks and updates Figures, if your pack contains those. Note that
 there's no guaranteed behavior for images referenced on Figures that were not
 included in a pack. You can just have an image missing, a completely unrelated
@@ -199,6 +199,10 @@ class TransferControl(GraphControl):
                 "--zip", help="Pack into a zip file rather than a tarball",
                 action="store_true")
         pack.add_argument(
+                "--figure", help="Include OMERO.Figures into the pack"
+                                 " (caveats apply)",
+                action="store_true")
+        pack.add_argument(
                 "--barchive", help="Pack into a file compliant with Bioimage"
                                    " Archive submission standards",
                 action="store_true")
@@ -225,6 +229,10 @@ class TransferControl(GraphControl):
                 action="store_true")
         unpack.add_argument(
                 "--merge", help="Use existing entities if possible",
+                action="store_true")
+        unpack.add_argument(
+                "--figure", help="Use OMERO.Figures if present"
+                                 " (caveats apply)",
                 action="store_true")
         unpack.add_argument(
                 "--folder", help="Pass path to a folder rather than a pack",

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -433,7 +433,6 @@ class TransferControl(GraphControl):
                                          args.barchive, args.simple,
                                          args.figure,
                                          self.metadata)
-
         print("Starting file copy...")
         self._copy_files(path_id_dict, folder, self.gateway)
         if args.simple:

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -431,6 +431,7 @@ class TransferControl(GraphControl):
         ome, path_id_dict = populate_xml(src_datatype, src_dataid, md_fp,
                                          self.gateway, self.hostname,
                                          args.barchive, args.simple,
+                                         args.figure,
                                          self.metadata)
 
         print("Starting file copy...")

--- a/test/integration/test_figure.py
+++ b/test/integration/test_figure.py
@@ -1,0 +1,172 @@
+# Copyright (C) 2023 The Jackson Laboratory
+# All rights reserved.
+#
+# Use is subject to license terms supplied in LICENSE.
+
+from omero_cli_transfer import TransferControl
+from cli import CLITest
+from omero.gateway import BlitzGateway
+
+import ezomero
+import pytest
+import os
+import tarfile
+import json
+
+
+class TestFigure(CLITest):
+
+    def setup_method(self, method):
+        super(TestFigure, self).setup_method(method)
+        self.cli.register("transfer", TransferControl, "TEST")
+        self.args += ["transfer"]
+        self.idonly = "-1"
+        self.imageid = "Image:-1"
+        self.datasetid = "Dataset:-1"
+        self.projectid = "Project:-1"
+        self.plateid = "Project:-1"
+        self.screenid = "Project:-1"
+        self.gw = BlitzGateway(client_obj=self.client)
+
+    def create_image(self, sizec=4, sizez=1, sizet=1, target_name=None):
+        images = self.import_fake_file(
+                images_count=2, sizeZ=sizez, sizeT=sizet, sizeC=sizec,
+                client=self.client)
+        images.append(self.create_test_image(100, 100, 1, 1, 1,
+                                             self.client.getSession()))
+        self.imageid = "Image:%s" % images[0].id.val
+        self.source = "Image:%s" % images[1].id.val
+        for image in images:
+            img = self.gw.getObject("Image", image.id.val)
+            img.getThumbnail(size=(96,), direct=False)
+        if target_name == "datasetid" or target_name == "projectid" or\
+           target_name == "idonly":
+            # Create Project/Dataset hierarchy
+            project = self.make_project(client=self.client)
+            self.project = self.gw.getObject("Project", project.id.val)
+            dataset = self.make_dataset(client=self.client)
+            self.dataset = self.gw.getObject("Dataset", dataset.id.val)
+            self.projectid = "Project:%s" % self.project.id
+            self.datasetid = "Dataset:%s" % self.dataset.id
+            self.idonly = "%s" % self.project.id
+            self.link(obj1=project, obj2=dataset)
+            for i in images:
+                self.link(obj1=dataset, obj2=i)
+
+    def delete_all(self):
+        pjs = self.gw.getObjects("Project")
+        for p in pjs:
+            pj_id = p.id
+            print(f"deleting project {pj_id}")
+            self.gw.deleteObjects("Project", [pj_id], deleteAnns=True,
+                                  deleteChildren=True, wait=True)
+        ds = self.gw.getObjects("Dataset")
+        for d in ds:
+            ds_id = d.id
+            print(f"deleting dataset {ds_id}")
+            self.gw.deleteObjects("Dataset", [ds_id], deleteAnns=True,
+                                  deleteChildren=True, wait=True)
+        scs = self.gw.getObjects("Screen")
+        for sc in scs:
+            sc_id = sc.id
+            print(f"deleting screen {sc_id}")
+            self.gw.deleteObjects("Screen", [sc_id], deleteAnns=True,
+                                  deleteChildren=True, wait=True)
+        pls = self.gw.getObjects("Plate")
+        for pl in pls:
+            pl_id = pl.id
+            print(f"deleting plate {pl_id}")
+            self.gw.deleteObjects("Plate", [pl_id], deleteAnns=True,
+                                  deleteChildren=True, wait=True)
+        ims = self.gw.getObjects("Image")
+        im_ids = []
+        for im in ims:
+            im_ids.append(im.id)
+            print(f"deleting image {im.id}")
+        if im_ids:
+            self.gw.deleteObjects("Image", im_ids, deleteAnns=True,
+                                  deleteChildren=True, wait=True)
+
+    def get_panel_json(image, index, page_x):
+        """Create a panel."""
+        channel = {'emissionWave': "400",
+                   'label': "DAPI",
+                   'color': "0000FF",
+                   'inverted': False,
+                   'active': True,
+                   'window': {'min': 0,
+                              'max': 255,
+                              'start': 0,
+                              'end': 255},
+                   }
+
+        pix = image.getPrimaryPixels()
+        size_x = pix.getSizeX().val
+        size_y = pix.getSizeY().val
+        # shapes coordinates are Image coordinates
+        # Red Line diagonal from corner to corner
+        # Arrow from other corner to centre
+        shapes = [{"type": "Rectangle", "x": size_x/4, "y": size_y/4,
+                   "width": size_x/2, "height": size_y/2,
+                   "strokeWidth": 4, "strokeColor": "#FFFFFF"},
+                  {"type": "Line", "x1": 0, "x2": size_x, "y1": 0,
+                   "y2": size_y, "strokeWidth": 5, "strokeColor": "#FF0000"},
+                  {"type": "Arrow", "x1": 0, "x2": size_x/2, "y1": size_y,
+                   "y2": size_y/2, "strokeWidth": 10, "strokeColor": "#FFFF00"},
+                  {"type": "Ellipse", "x": size_x/2, "y": size_y/2,
+                   "radiusX": size_x/3, "radiusY": size_y/2, "rotation": 45,
+                   "strokeWidth": 10, "strokeColor": "#00FF00"}]
+
+        # This works if we have Units support (OMERO 5.1)
+        px = image.getPrimaryPixels().getPhysicalSizeX()
+        py = image.getPrimaryPixels().getPhysicalSizeY()
+        pz = image.getPrimaryPixels().getPhysicalSizeZ()
+        img_json = {
+            "imageId": image.getId().getValue(),
+            "name": "test_image",  # image.getName().getValue()
+            "width": 100 * (index + 1),
+            "height": 100 * (index + 1),
+            "sizeZ": pix.getSizeZ().val,
+            "theZ": 0,
+            "sizeT": pix.getSizeT().val,
+            "theT": 0,
+            # rdef -> used at panel creation then deleted
+            "channels": [channel],
+            "orig_width": size_x,
+            "orig_height": size_y,
+            "x": page_x,
+            "y": index * 200,
+            'datasetName': "TestDataset",
+            'datasetId': 123,
+            'pixel_size_x': None if px is None else px.getValue(),
+            'pixel_size_y': None if py is None else py.getValue(),
+            'pixel_size_z': None if pz is None else pz.getValue(),
+            'pixel_size_x_symbol': '\xB5m' if px is None else px.getSymbol(),
+            'pixel_size_z_symbol': None if pz is None else pz.getSymbol(),
+            'pixel_size_x_unit': None if px is None else str(px.getUnit()),
+            'pixel_size_z_unit': None if pz is None else str(pz.getUnit()),
+            'deltaT': [],
+            "zoom": 100 + (index * 50),
+            "dx": 0,
+            "dy": 0,
+            "rotation": 100 * index,
+            "rotation_symbol": '\xB0',
+            "max_export_dpi": 1000,
+            "shapes": shapes,
+        }
+        return img_json
+
+    def create_figure(self, images):
+        """Create JSON to export figure."""
+        figure_json = {"version": 2,
+                       "paper_width": 595,
+                       "paper_height": 842,
+                       "page_size": "A4",
+                       }
+        panels = []
+        for idx, image in enumerate(images):
+            panels.append(self.get_panel_json(image, 0, 50 + (idx * 300)))
+            panels.append(self.get_panel_json(image, 1, 50 + (idx * 300)))
+        figure_json['panels'] = panels
+        json_string = json.dumps(figure_json)
+        return json_string

--- a/test/integration/test_figure.py
+++ b/test/integration/test_figure.py
@@ -7,10 +7,10 @@ from omero_cli_transfer import TransferControl
 from cli import CLITest
 from omero.gateway import BlitzGateway
 
-import ezomero
-import pytest
-import os
-import tarfile
+# import ezomero
+# import pytest
+# import os
+# import tarfile
 import json
 
 
@@ -87,7 +87,7 @@ class TestFigure(CLITest):
             self.gw.deleteObjects("Image", im_ids, deleteAnns=True,
                                   deleteChildren=True, wait=True)
 
-    def get_panel_json(image, index, page_x):
+    def get_panel_json(self, image, index, page_x):
         """Create a panel."""
         channel = {'emissionWave': "400",
                    'label': "DAPI",
@@ -106,16 +106,17 @@ class TestFigure(CLITest):
         # shapes coordinates are Image coordinates
         # Red Line diagonal from corner to corner
         # Arrow from other corner to centre
-        shapes = [{"type": "Rectangle", "x": size_x/4, "y": size_y/4,
-                   "width": size_x/2, "height": size_y/2,
-                   "strokeWidth": 4, "strokeColor": "#FFFFFF"},
-                  {"type": "Line", "x1": 0, "x2": size_x, "y1": 0,
-                   "y2": size_y, "strokeWidth": 5, "strokeColor": "#FF0000"},
-                  {"type": "Arrow", "x1": 0, "x2": size_x/2, "y1": size_y,
-                   "y2": size_y/2, "strokeWidth": 10, "strokeColor": "#FFFF00"},
-                  {"type": "Ellipse", "x": size_x/2, "y": size_y/2,
-                   "radiusX": size_x/3, "radiusY": size_y/2, "rotation": 45,
-                   "strokeWidth": 10, "strokeColor": "#00FF00"}]
+        shapes = [
+            {"type": "Rectangle", "x": size_x/4, "y": size_y/4,
+             "width": size_x/2, "height": size_y/2,
+             "strokeWidth": 4, "strokeColor": "#FFFFFF"},
+            {"type": "Line", "x1": 0, "x2": size_x, "y1": 0,
+             "y2": size_y, "strokeWidth": 5, "strokeColor": "#FF0000"},
+            {"type": "Arrow", "x1": 0, "x2": size_x/2, "y1": size_y,
+             "y2": size_y/2, "strokeWidth": 10, "strokeColor": "#FFFF00"},
+            {"type": "Ellipse", "x": size_x/2, "y": size_y/2,
+             "radiusX": size_x/3, "radiusY": size_y/2, "rotation": 45,
+             "strokeWidth": 10, "strokeColor": "#00FF00"}]
 
         # This works if we have Units support (OMERO 5.1)
         px = image.getPrimaryPixels().getPhysicalSizeX()

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -149,6 +149,7 @@ class TestTransfer(CLITest):
                 self.cli.invoke(args, strict=True)
         self.delete_all()
 
+
     @pytest.mark.parametrize('target_name', sorted(SUPPORTED))
     def test_pack_special(self, target_name, tmpdir):
         if target_name == "datasetid" or target_name == "projectid" or\

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -149,7 +149,6 @@ class TestTransfer(CLITest):
                 self.cli.invoke(args, strict=True)
         self.delete_all()
 
-
     @pytest.mark.parametrize('target_name', sorted(SUPPORTED))
     def test_pack_special(self, target_name, tmpdir):
         if target_name == "datasetid" or target_name == "projectid" or\


### PR DESCRIPTION
This update includes the `--figure` optional argument to `omero transfer pack` and `unpack`. On `pack`, it will include any figures that refer to any of the Images in the pack, and on `unpack` it will use any figures included in the pack, if any. 

The big caveats: 
- there _might_ be some impact on performance on the `pack` side, depending on how many Figures a user has access to. There's no efficient query for which Figures refer to an Image, so we need to download and search every Figure JSON to look for that.
- There's no guaranteed behavior for Figures that include images that are NOT in the pack. They might just not show up destination-side, you might get a permission error, you might end up getting a different image altogether displayed. Use carefully!