### PR TITLE
migrate to Docker Compose V2 using 'docker compose'

### DIFF
--- a/.omero/compose
+++ b/.omero/compose
@@ -9,4 +9,4 @@ PROJECT=${PROJECT:-$(get_project_name)}
 # making use of COMPOSE_PROJECT_NAME
 
 cd $dir
-exec docker-compose -p ${PROJECT} "$@"
+exec docker compose -p ${PROJECT} "$@"


### PR DESCRIPTION
Since July 2023, Docker Compose V1 (`docker-compose`) is no longer included in Docker Desktop, and it is highly recommended to [migrate to Docker Compose V2](https://docs.docker.com/compose/migrate/) (`docker compose`). 

Tested on my Docker (version 20.10.19) installation on Linux: `docker-compose` was not automatically aliased to `docker compose` so `.omero/docker cli` failed previously. After changing to `docker compose`, tests passed. This should work on all currently supported versions of Docker (according to their migration page linked above), but would be nice for someone on Windows (@erickmartins?) to confirm.

Another option would be to replace with `docker compose --compatibility` which keeps the container naming scheme of V1, if any tests refer to hard-coded container names. But both ran fine for me and I don't know how long `--compatibility` will be supported.