### PR TITLE
Added plugin interface for external packers

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,23 @@ NOTE: please refer to optional requirement instructions below and consider that 
 - `prepare` requires [bftools](https://bio-formats.readthedocs.io/en/stable/users/comlinetools/index.html) to work (in particular, we need to be able to run `showinf`). The easiest way to install this is by using conda; A simple `conda install -c bioconda bftools` on your conda environment should suffice.
 - Note that this is a Java application. The conda package will install a JDK for you if necessary, but if you're installing it for yourself you'll need to make sure Java is available.
 - This tool runs `showinf` in a subprocess and needs to be able to parse the output. This can be problematic if your `stdout` is not set to UTF-8; it can mess up special characters is e.g. measurement units and lead to XML validation errors. In addition to that, Java itself might output data in non-UTF-8 encodings, in which case it might be necessary to set `JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8`.
+
+
+### Plugin interface for external packers
+
+External export formats can be used by omoero-cli-transfer via plugin interface:
+```
+omero transfer pack --plugin my-exporter Dataset:111 path/to/my_export.zip
+```
+
+Plugins for omero-cli-transfer can be created by providing an entry point with group name `omero_cli_transfer.pack.plugin`. Entry points are defined in
+`setup.py` or `pyproject.toml`, see e.g. the [arc plugin](https://github.com/cmohl2013/omero-arc), which transfers omero projects to ARC repositories.
+
+
+The entry point must be a function with following arguments:
+  * `ome_object`:  the omero object wrapper to pack
+  * `destination_path`: the path to export to
+  * `tmp_path`: the path where downloaded images and `transfer.xml` are located
+  * `image_filenames_mapping`: dict that maps image ids to filenames
+
+The entry point must be defined in the setuptools configuration file (`setup.py` or `pyproject.toml`), see e.g. the entrypoint definition of the arc plugin: [pyproject.toml](https://github.com/cmohl2013/omero-arc/blob/main/pyproject.toml)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 An OMERO CLI plugin for creating and using transfer packets between OMERO servers.
 
-Transfer packets contain objects and annotations. This project creates a zip file from an object 
-(Project, Dataset, Image, Screen, Plate) containing all original files necessary to create the images 
+Transfer packets contain objects and annotations. This project creates a zip file from an object
+(Project, Dataset, Image, Screen, Plate) containing all original files necessary to create the images
 in that object, plus an XML file detailing the links between entities, annotations and ROIs thereof.
 
 The CLI plugin add the subcommand `transfer`, which in its turn has two further subcommands `omero transfer pack` and `omero transfer unpack`. Both subcommands (pack and unpack) will use an existing OMERO session created via CLI or prompt the user for parameters to create one.
@@ -16,7 +16,7 @@ The CLI plugin add the subcommand `transfer`, which in its turn has two further 
 tl;dr: if you have `python>=3.8`, a simple `pip install omero-cli-transfer` _might_ do. We recommend conda, though.
 
 `omero-cli-transfer` requires at least Python 3.8. This is due to `ome-types` requiring that as well;
-this package relies heavily on it, and it is not feasible without it. 
+this package relies heavily on it, and it is not feasible without it.
 
 Of course, this CAN be an issue, especially given `omero-py` _officially_ only supports Python 3.6. However,
 it is possible to run `omero-py` in Python 3.8 or newer as well. Our recommended way to do so it using `conda`.
@@ -28,10 +28,10 @@ pip install omero-cli-transfer
 ```
 It is possible to do the same thing without `conda` as long as your python/pip version is at least 3.8,
 but that will require locally building a wheel for `zeroc-ice` (which pip does automatically) - it is a
-process that can be anything from "completely seamless and without issues" to "I need to install every 
+process that can be anything from "completely seamless and without issues" to "I need to install every
 dependency ever imagined". Try at your own risk.
 
-If you want optional RO-Crate exports, you can do 
+If you want optional RO-Crate exports, you can do
 ```
 pip install omero-cli-transfer[rocrate]
 ```
@@ -59,7 +59,10 @@ about the files (name, mimetype).
 
 `--simple` creates a "human-readable" package; one folder per project or dataset is created and image files are placed according to where they came from in the OMERO server. Note that a package generated with this option is not guaranteed to work with `unpack`, though it often will.
 
-`--metadata` allows you to specify which transfer metadata will be saved in `transfer.xml` as possible MapAnnotation values to the images. Defaults to image ID, timestamp, software version, source hostname, md5, source username, source group. 
+`--metadata` allows you to specify which transfer metadata will be saved in `transfer.xml` as possible MapAnnotation values to the images. Defaults to image ID, timestamp, software version, source hostname, md5, source username, source group.
+
+`--plugin` allows oyu to export omero data to a desired format by using an external plugin. See for example the [arc plugin](https://github.com/cmohl2013/omero-arc), which exports omero
+projects to ARC repositories.
 
 Examples:
 ```
@@ -67,6 +70,7 @@ omero transfer pack Image:123 transfer_pack.tar
 omero transfer pack --zip Image:123 transfer_pack.zip
 omero transfer pack Dataset:1111 /home/user/new_folder/new_pack.tar
 omero transfer pack 999 tarfile.tar  # equivalent to Project:999
+omero transfer pack --plugin arc Dataset:111 path/to/my/arc/repo
 ```
 
 ## `omero transfer unpack`
@@ -85,7 +89,7 @@ Note that unpack needs to be able to identify the images it imports inequivocall
 already owns entities with the same name as ones defined in `transfer.xml`,
 effectively merging the "new" unpacked entities with existing ones.
 
-`--metadata` allows you to specify which transfer metadata will be used from `transfer.xml` as MapAnnotation values to the images. Fields that do not exist on `transfer.xml` will be ignored. Defaults to image ID, timestamp, software version, source hostname, md5, source username, source group. 
+`--metadata` allows you to specify which transfer metadata will be used from `transfer.xml` as MapAnnotation values to the images. Fields that do not exist on `transfer.xml` will be ignored. Defaults to image ID, timestamp, software version, source hostname, md5, source username, source group.
 
 Examples:
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ omero transfer pack Image:123 transfer_pack.tar
 omero transfer pack --zip Image:123 transfer_pack.zip
 omero transfer pack Dataset:1111 /home/user/new_folder/new_pack.tar
 omero transfer pack 999 tarfile.tar  # equivalent to Project:999
-omero transfer pack --plugin arc Dataset:111 path/to/my/arc/repo
+omero transfer pack --plugin arc Project:999 path/to/my/arc/repo
 ```
 
 ## `omero transfer unpack`
@@ -146,14 +146,20 @@ External export formats can be used by omoero-cli-transfer via plugin interface:
 omero transfer pack --plugin my-exporter Dataset:111 path/to/my_export.zip
 ```
 
-Plugins for omero-cli-transfer can be created by providing an entry point with group name `omero_cli_transfer.pack.plugin`. Entry points are defined in
-`setup.py` or `pyproject.toml`, see e.g. the [arc plugin](https://github.com/cmohl2013/omero-arc), which transfers omero projects to ARC repositories.
+#### Example: ARC plugin
+
+With the [arc plugin](https://github.com/cmohl2013/omero-arc), OMERO projects can be transferred to ARC
+repositories.
+```
+omero transfer pack --plugin arc Project:111 path/to/my/arc_repo
+```
+
+
+Plugins for omero-cli-transfer can be created by providing an entry point with group name `omero_cli_transfer.pack.plugin`. Entry points are defined in `setup.py` or `pyproject.toml`, , see e.g. the [entrypoint definition](https://github.com/cmohl2013/omero-arc/blob/main/pyproject.toml) of the arc plugin.
 
 
 The entry point must be a function with following arguments:
-  * `ome_object`:  the omero object wrapper to pack
-  * `destination_path`: the path to export to
-  * `tmp_path`: the path where downloaded images and `transfer.xml` are located
-  * `image_filenames_mapping`: dict that maps image ids to filenames
-
-The entry point must be defined in the setuptools configuration file (`setup.py` or `pyproject.toml`), see e.g. the entrypoint definition of the arc plugin: [pyproject.toml](https://github.com/cmohl2013/omero-arc/blob/main/pyproject.toml)
+  * `ome_object`:  The omero object wrapper to pack.
+  * `destination_path`: The export target path.
+  * `tmp_path`: The temporary path where downloaded images and `transfer.xml` are located.
+  * `image_filenames_mapping`: A dict that maps image ids to filenames.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ NOTE: please refer to optional requirement instructions below and consider that 
 
 ### Plugin interface for external packers
 
-External export formats can be used by omoero-cli-transfer via plugin interface:
+External export formats can be used by omero-cli-transfer via plugin interface:
 ```
 omero transfer pack --plugin my-exporter Dataset:111 path/to/my_export.zip
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ about the files (name, mimetype).
 
 `--metadata` allows you to specify which transfer metadata will be saved in `transfer.xml` as possible MapAnnotation values to the images. Defaults to image ID, timestamp, software version, source hostname, md5, source username, source group.
 
-`--plugin` allows oyu to export omero data to a desired format by using an external plugin. See for example the [arc plugin](https://github.com/cmohl2013/omero-arc), which exports omero
+`--plugin` allows you to export omero data to a desired format by using an external plugin. See for example the [arc plugin](https://github.com/cmohl2013/omero-arc), which exports omero
 projects to ARC repositories.
 
 Examples:

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -453,16 +453,13 @@ class TransferControl(GraphControl):
             Plugins for omero-cli-transfer can be created by providing
             an entry point with group name omero_cli_transfer.pack.plugin
 
-            The entry point must be a class with following constructor
+            The entry point must be a function with following
             arguments:
               ome_object:  the omero object wrapper to pack
               destination_path: the path to export to
               tmp_path: the path where downloaded images and transfer.xml
                 are located
               image_filenames_mapping: dict that maps image ids to filenames
-
-            The entry point class must provide the method 'pack()'
-
             """
             from pkg_resources import iter_entry_points
             entry_points = []
@@ -473,14 +470,13 @@ class TransferControl(GraphControl):
                 raise ValueError(f"Pack plugin {args.plugin} not found")
             else:
                 assert len(entry_points) == 1
-                pack_plugin_cls = entry_points[0]
-                pack_plugin = pack_plugin_cls(
+                pack_plugin_func = entry_points[0]
+                pack_plugin_func(
                     ome_object=obj,
                     destination_path=Path(tar_path),
                     tmp_path=Path(folder),
                     image_filenames_mapping=path_id_dict,
                     conn=self.gateway)
-                pack_plugin.pack()
         else:
             self._package_files(os.path.splitext(tar_path)[0], args.zip,
                                 folder)

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -220,6 +220,9 @@ class TransferControl(GraphControl):
                      'orig_user', 'orig_group'], nargs='+',
             help="Metadata field to be added to MapAnnotation"
         )
+        pack.add_argument(
+                "--plugin", help="Use external plugin for packing.",
+                type=str)
         pack.add_argument("filepath", type=str, help=file_help)
 
         file_help = ("Path to where the zip file is saved")
@@ -445,6 +448,26 @@ class TransferControl(GraphControl):
             print(f"Creating RO-Crate metadata at {md_fp}.")
             populate_rocrate(src_datatype, ome, os.path.splitext(tar_path)[0],
                              path_id_dict, folder)
+        
+        if args.plugin:
+            from pkg_resources import iter_entry_points
+            entry_points = []
+            for p in iter_entry_points(group="omero_cli_transfer.pack.plugin"):
+                if p.name==args.plugin:
+                    entry_points.append(p.load())
+            if len(entry_points) == 0:
+                raise ValueError(f"Pack plugin {args.plugin} not found")
+            else:
+                assert len(entry_points) == 1
+                pack_plugin_cls = entry_points[0]
+                pack_plugin = pack_plugin_cls(ome_object=obj,
+                                              destination_path=Path(tar_path),
+                                              tmp_path=Path(folder),
+                                              image_filenames_mapping=path_id_dict,
+                                              conn=self.gateway)
+                pack_plugin.pack()
+
+        
         else:
             self._package_files(os.path.splitext(tar_path)[0], args.zip,
                                 folder)

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -448,26 +448,39 @@ class TransferControl(GraphControl):
             print(f"Creating RO-Crate metadata at {md_fp}.")
             populate_rocrate(src_datatype, ome, os.path.splitext(tar_path)[0],
                              path_id_dict, folder)
-        
         if args.plugin:
+            """
+            Plugins for omero-cli-transfer can be created by providing
+            an entry point with group name omero_cli_transfer.pack.plugin
+
+            The entry point must be a class with following constructor
+            arguments:
+              ome_object:  the omero object wrapper to pack
+              destination_path: the path to export to
+              tmp_path: the path where downloaded images and transfer.xml
+                are located
+              image_filenames_mapping: dict that maps image ids to filenames
+
+            The entry point class must provide the method 'pack()'
+
+            """
             from pkg_resources import iter_entry_points
             entry_points = []
             for p in iter_entry_points(group="omero_cli_transfer.pack.plugin"):
-                if p.name==args.plugin:
+                if p.name == args.plugin:
                     entry_points.append(p.load())
             if len(entry_points) == 0:
                 raise ValueError(f"Pack plugin {args.plugin} not found")
             else:
                 assert len(entry_points) == 1
                 pack_plugin_cls = entry_points[0]
-                pack_plugin = pack_plugin_cls(ome_object=obj,
-                                              destination_path=Path(tar_path),
-                                              tmp_path=Path(folder),
-                                              image_filenames_mapping=path_id_dict,
-                                              conn=self.gateway)
+                pack_plugin = pack_plugin_cls(
+                    ome_object=obj,
+                    destination_path=Path(tar_path),
+                    tmp_path=Path(folder),
+                    image_filenames_mapping=path_id_dict,
+                    conn=self.gateway)
                 pack_plugin.pack()
-
-        
         else:
             self._package_files(os.path.splitext(tar_path)[0], args.zip,
                                 folder)


### PR DESCRIPTION
As discussed in issue #68 I started the development of an omero-arc exporter: https://github.com/cmohl2013/omero-arc

Following a suggestion from @joshmoore, the ARC export function was not directly integrated into omero-cli-transfer.
Instead, a plugin interface was created in omero-cli-transfer. omero-arc exposes an entrypoint that can be consumed by omero-cli-transfer. 

* added optional argument `--plugin` in omero_cli_transfer.py 
* added plugin interface in omero_cli_transfer.py
* added some documentation in README.md to explain how plugins can developed and how it is used

Advantages: 
 * The omero-arc is still in an early stage and changes will occur frequently. By not directly integrating to omero-cli-transfer, we avoid repeaded pull requests to omero-cli-transfer
 * The changes in omero-cli-transfer are very small and no extra dependencies are needed.
 * The plugin interface can be used by other external exporters in the future. 

I did not add tests for the plugin interface. However, there are integration tests in omero-arc to ensure that omero-arc works with omero-cli-transfer: https://github.com/cmohl2013/omero-arc/blob/main/test/test_arc_transfer.py. So the plugin interface is tested at least there.
If a test in omero-cli-transfer is needed, a dummy entry point should be created somehow.