### PR TITLE
sets action to "published" so it runs on prereleases

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -8,7 +8,7 @@ name: Release to PyPI
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   release:

--- a/.github/workflows/upload_to_test_pypi.yml
+++ b/.github/workflows/upload_to_test_pypi.yml
@@ -8,7 +8,7 @@ name: Release to Test PyPI
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
Minor change to publishing GH actions to that pre-releases are pushed to PyPI.