### PR TITLE
raising a `NonzeroReturnCode` when download fails

### DIFF
--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -36,5 +36,7 @@ jobs:
           repository: ome/omero-test-infra
           path: .omero
           ref: ${{ secrets.OMERO_TEST_INFRA_REF }}
-      - name: Build and run OMERO tests
+      - name: Build and run standard tests
         run: POLICY_BINARY_ACCESS=+read,+write,+image,+plate .omero/docker $STAGE
+      - name: Build and run no-plate tests
+        run: .omero/docker $STAGE

--- a/.omeroci/cli-build
+++ b/.omeroci/cli-build
@@ -8,6 +8,8 @@ set -x
 TARGET=${TARGET:-..}
 cd $TARGET
 
+BIN_ACCESS=$(/opt/omero/server/venv3/bin/omero config get omero.policy.binary_access)
+
 GUESS=${PWD#*omero-cli-*}
 PLUGIN=${PLUGIN:-$GUESS}
 
@@ -22,5 +24,8 @@ conda activate omero
 
 export OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
 omero $PLUGIN -h
-
-python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -vs
+if [[ $BIN_ACCESS =~ "+plate" ]]; then
+    python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -vs -m "not limit_plate"
+else
+    python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -vs -m limit_plate
+fi

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Default is `all` and will create the archive. With `none`, only the `transfer.xm
 file is created, in which case the last cli argument is the path where
 the `transfer.xml` file will be written.
 
+`--ignore_errors` gnores any download/export errors during the pack process,
+often the result of servers which do not allow Plate downloads (but will
+ignore any non-zero return code from `omero download` or `omero export`).
+
 
 Examples:
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ezomero>=2.0.0
-ome-types>=0.4.2
+ezomero>=2.0.0<3.0.0
+ome-types>=0.5.0<0.6.0
 setuptools>=58.0.0

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     url="https://github.com/TheJacksonLaboratory/omero-cli-transfer",
     install_requires=[
         'ezomero>=2.1.0, <3.0.0',
-        'ome-types>=0.5.0,<0.6.0'
+        'ome-types==0.5.1.post1'
     ],
     extras_require={
         "rocrate": ["rocrate==0.7.0"],

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     packages=['', 'omero.plugins'],
     package_dir={"": "src"},
     name="omero-cli-transfer",
-    version='1.0.0rc1',
+    version='1.1.0',
     maintainer="Erick Ratamero",
     maintainer_email="erick.ratamero@jax.org",
     description=("A set of utilities for exporting a transfer"
@@ -96,7 +96,7 @@ setup(
     url="https://github.com/TheJacksonLaboratory/omero-cli-transfer",
     install_requires=[
         'ezomero>=2.1.0, <3.0.0',
-        'ome-types>=0.4.5,<0.5.0'
+        'ome-types>=0.5.0,<0.6.0'
     ],
     extras_require={
         "rocrate": ["rocrate==0.7.0"],

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -336,7 +336,15 @@ class TransferControl(GraphControl):
                     if rel_path == "pixel_images" or fileset is None:
                         filepath = str(Path(subfolder) /
                                        (str(clean_id) + ".tiff"))
-                        cli.invoke(['export', '--file', filepath, id])
+                        try:
+                            cli.invoke(['export', '--file', filepath, id],
+                                       strict=True)
+                        except NonZeroReturnCode:
+                            print("A file could not be exported - this is "
+                                  "generally due to a server not allowing"
+                                  " binary downloads.")
+                            shutil.rmtree(folder)
+                            raise NonZeroReturnCode(1, "Download not allowed")
                         downloaded_ids.append(id)
                     else:
                         try:
@@ -345,7 +353,7 @@ class TransferControl(GraphControl):
                         except NonZeroReturnCode:
                             print("A file could not be downloaded - this is "
                                   "generally due to a server not allowing"
-                                  " plate downloads.")
+                                  " binary downloads.")
                             shutil.rmtree(folder)
                             raise NonZeroReturnCode(1, "Download not allowed")
                         for fs_image in fileset.copyImages():
@@ -357,7 +365,14 @@ class TransferControl(GraphControl):
                 ann_folder = str(Path(subfolder).parent)
                 os.makedirs(ann_folder, mode=DIR_PERM, exist_ok=True)
                 id = "File" + id
-                cli.invoke(['download', id, subfolder])
+                try:
+                    cli.invoke(['download', id, subfolder], strict=True)
+                except NonZeroReturnCode:
+                    print("A file could not be downloaded - this is "
+                          "generally due to a server not allowing"
+                          " binary downloads.")
+                    shutil.rmtree(folder)
+                    raise NonZeroReturnCode(1, "Download not allowed")
 
     def _package_files(self, tar_path: str, zip: bool, folder: str):
         if zip:

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -504,7 +504,6 @@ class TransferControl(GraphControl):
                                          args.barchive, args.simple,
                                          args.figure,
                                          self.metadata)
-
         if args.binaries == "all":
             print("Starting file copy...")
             self._copy_files(path_id_dict, folder, args.ignore_errors,

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -382,8 +382,8 @@ class TransferControl(GraphControl):
                         cli.invoke(['download', id, subfolder], strict=True)
                     except NonZeroReturnCode:
                         print("A file could not be downloaded - this is "
-                            "generally due to a server not allowing"
-                            " binary downloads.")
+                              "generally due to a server not allowing"
+                              " binary downloads.")
                         shutil.rmtree(folder)
                         raise NonZeroReturnCode(1, "Download not allowed")
                 else:


### PR DESCRIPTION
Previously, any failures of `omero download` when trying to download images (often due to binary permissions not allowing for them) were silent; a final pack would still be produced, only missing the relevant binary files. This PR implements checking return codes for all `omero download` and `omero export` operations, and fails/cleans up temp files in case any of them fails.