### PR TITLE
Making reference to image IDs not contained in a pack negative in Figures

### DIFF
--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import xml.etree.cElementTree as ETree
 import os
 import copy
+import re
 
 
 def create_or_set_projects(pjs: List[Project], conn: BlitzGateway,
@@ -287,9 +288,14 @@ def update_figure_refs(ann: FileAnnotation, ans: List[Annotation],
             filedata = file.read()
         for src_id, dest_id in img_map.items():
             clean_id = int(src_id.split(":")[-1])
-            src_str = f"\"imageId\": {clean_id}"
-            dest_str = f"\"imageId\": {dest_id}"
+            src_str = f"\"imageId\": {clean_id},"
+            dest_str = f"\"imageId\": {dest_id},"
             filedata = filedata.replace(src_str, dest_str)
+        for fig in re.finditer("\"imageId\": ([0-9]+),", filedata):
+            if fig.group(1) not in img_map.values():
+                src_str = f"\"imageId\": {clean_id},"
+                dest_str = f"\"imageId\": {str(-1)},"
+                filedata = filedata.replace(src_str, dest_str)
         with open(dest_path, 'w') as file:
             file.write(filedata)
     return

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -292,8 +292,8 @@ def update_figure_refs(ann: FileAnnotation, ans: List[Annotation],
             dest_str = f"\"imageId\": {dest_id},"
             filedata = filedata.replace(src_str, dest_str)
         for fig in re.finditer("\"imageId\": ([0-9]+),", filedata):
-            if fig.group(1) not in img_map.values():
-                src_str = f"\"imageId\": {clean_id},"
+            if int(fig.group(1)) not in img_map.values():
+                src_str = f"\"imageId\": {fig.group(1)},"
                 dest_str = f"\"imageId\": {str(-1)},"
                 filedata = filedata.replace(src_str, dest_str)
         with open(dest_path, 'w') as file:


### PR DESCRIPTION
This addresses #82 - in short, currently we have an undefined behavior regarding image IDs in Figures. for Images contained in a pack, references to their IDs are updated in transferred figures to point to the destination ID; for all other images in those figures, their IDs are untouched.

In practice, this can mean that Figures will have empty panels (in case the source ID for non-pack images do not exist/are outside permissions in the destination side) or have "wrong" images (in case the source ID is accessible destination-side). 

This PR changes all non-pack image IDs to `-1` - that ensures that 1) the inconsistent behavior described is eliminated, panels will always be empty; 2) clearly signals to users that this is a deliberate choice; 3) indicates that those images were not part of the pack.