### PR TITLE
packing list of objects

### DIFF
--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import xml.etree.cElementTree as ETree
 import os
 import copy
+import re
 
 
 def create_or_set_projects(pjs: List[Project], conn: BlitzGateway,
@@ -287,9 +288,14 @@ def update_figure_refs(ann: FileAnnotation, ans: List[Annotation],
             filedata = file.read()
         for src_id, dest_id in img_map.items():
             clean_id = int(src_id.split(":")[-1])
-            src_str = f"\"imageId\": {clean_id}"
-            dest_str = f"\"imageId\": {dest_id}"
+            src_str = f"\"imageId\": {clean_id},"
+            dest_str = f"\"imageId\": {dest_id},"
             filedata = filedata.replace(src_str, dest_str)
+        for fig in re.finditer("\"imageId\": ([0-9]+),", filedata):
+            if fig.group(1) not in img_map.values():
+                src_str = f"\"imageId\": {clean_id},"
+                dest_str = f"\"imageId\": {str(-1)},"
+                filedata = filedata.replace(src_str, dest_str)
         with open(dest_path, 'w') as file:
             file.write(filedata)
     return

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -292,8 +292,8 @@ def update_figure_refs(ann: FileAnnotation, ans: List[Annotation],
             dest_str = f"\"imageId\": {dest_id},"
             filedata = filedata.replace(src_str, dest_str)
         for fig in re.finditer("\"imageId\": ([0-9]+),", filedata):
-            if fig.group(1) not in img_map.values():
-                src_str = f"\"imageId\": {clean_id},"
+            if int(fig.group(1)) not in img_map.values():
+                src_str = f"\"imageId\": {fig.group(1)},"
                 dest_str = f"\"imageId\": {str(-1)},"
                 filedata = filedata.replace(src_str, dest_str)
         with open(dest_path, 'w') as file:

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -31,11 +31,12 @@ from ome_types.model import XMLAnnotation, OME
 from ome_types import from_xml, to_xml
 from omero.sys import Parameters
 from omero.rtypes import rstring
-from omero.cli import CLI, GraphControl
+from omero.cli import CLI, GraphControl, GraphArg
 from omero.cli import ProxyStringType, NonZeroReturnCode
 from omero.gateway import BlitzGateway
 from omero.model import Image, Dataset, Project, Plate, Screen
 from omero.grid import ManagedRepositoryPrx as MRepo
+
 
 DIR_PERM = 0o755
 MD5_BUF_SIZE = 65536
@@ -192,7 +193,22 @@ def gateway_required(func: Callable) -> Callable:
     return _wrapper
 
 
+def cmd_type():
+    import omero
+    import omero.all
+    return omero.cmd.GraphModify2
+
+
+def defaultProjectGraphArg(input):
+    if len(input.split(":")) == 1:
+        input = "Project:" + input
+    g = GraphArg(cmd_type())
+    ret = g.__call__(input)
+    return ret
+
+
 class TransferControl(GraphControl):
+
 
     def _configure(self, parser):
         parser.add_login_arguments()
@@ -203,7 +219,7 @@ class TransferControl(GraphControl):
 
         render_type = ProxyStringType("Project")
         obj_help = ("Object to be packed for transfer")
-        pack.add_argument("object", type=render_type, help=obj_help)
+        pack.add_argument("object", type=defaultProjectGraphArg, help=obj_help)
         file_help = ("Path to where the packed file will be saved")
         pack.add_argument(
                 "--zip", help="Pack into a zip file rather than a tarball",

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -468,6 +468,7 @@ class TestTransfer(CLITest):
         self.delete_all()
 
     @pytest.mark.parametrize('packing', ["tar", "zip"])
+    @pytest.mark.parametrize('target_name', sorted(SUPPORTED))
     def test_pack_unpack_multiple_projs(self, target_name, packing, tmpdir):
         if target_name == "projectid" or target_name == "idonly":
             projects = []
@@ -491,6 +492,10 @@ class TestTransfer(CLITest):
             self.run_asserts(target_name, multiple, span)
             self.delete_all()
             span = False
+            projects = []
+            for i in range(3):
+                self.create_image(target_name=target_name)
+                projects.append(self.project.id)
             target = f"Project:{projects[0]},{projects[-1]}"
             if packing == "tar":
                 name = 'test.tar'


### PR DESCRIPTION
This PR adds capability for packing multiple objects in a single file - both in the `Project:1-5` format (for projects 1 through 5) and `Project:1,3,5` (for projects 1, 3 and 5). Unpacking such a file should recreate all entities from the origin side. It also includes tests for this new feature.
