### PR TITLE
using updated pytest interface

### DIFF
--- a/.omeroci/cli-build
+++ b/.omeroci/cli-build
@@ -23,9 +23,10 @@ conda init
 conda activate omero
 
 export OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
+export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
 omero $PLUGIN -h
 if [[ $BIN_ACCESS =~ "+plate" ]]; then
-    python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -vs -m "not limit_plate"
+    pytest -v -m "not limit_plate"
 else
-    python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -vs -m limit_plate
+    pytest -v -m limit_plate
 fi

--- a/.omeroci/py-setup
+++ b/.omeroci/py-setup
@@ -19,7 +19,8 @@ conda init
 conda create -n omero python=3.9
 conda activate omero
 pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl
-conda install -c bioconda bftools
+conda install -c bioconda bftools 
+pip install pytest restview mox3
 
 cd $TARGET
 cd $(setup_dir)

--- a/setup.py
+++ b/setup.py
@@ -5,71 +5,10 @@
 # Use is subject to license terms supplied in LICENSE.
 
 import os
-import sys
 from setuptools import setup
-from setuptools.command.test import test as test_command
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
-
-
-class PyTest(test_command):
-    user_options = [
-        ('test-path=', 't', "base dir for test collection"),
-        ('test-ice-config=', 'i',
-         "use specified 'ice config' file instead of default"),
-        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-        ('test-marker=', 'm', "only run tests including 'marker'"),
-        ('test-no-capture', 's', "don't suppress test output"),
-        ('test-failfast', 'x', "Exit on first error"),
-        ('test-verbose', 'v', "more verbose output"),
-        ('test-quiet', 'q', "less verbose output"),
-        ('junitxml=', None, "create junit-xml style report file at 'path'"),
-        ('pdb', None, "fallback to pdb on error"),
-        ]
-
-    def initialize_options(self):
-        test_command.initialize_options(self)
-        self.test_pythonpath = None
-        self.test_string = None
-        self.test_marker = None
-        self.test_path = 'test'
-        self.test_failfast = False
-        self.test_quiet = False
-        self.test_verbose = False
-        self.test_no_capture = False
-        self.junitxml = None
-        self.pdb = False
-        self.test_ice_config = None
-
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = [self.test_path]
-        if self.test_string is not None:
-            self.test_args.extend(['-k', self.test_string])
-        if self.test_marker is not None:
-            self.test_args.extend(['-m', self.test_marker])
-        if self.test_failfast:
-            self.test_args.extend(['-x'])
-        if self.test_verbose:
-            self.test_args.extend(['-v'])
-        if self.test_quiet:
-            self.test_args.extend(['-q'])
-        if self.junitxml is not None:
-            self.test_args.extend(['--junitxml', self.junitxml])
-        if self.pdb:
-            self.test_args.extend(['--pdb'])
-        self.test_suite = True
-        if 'ICE_CONFIG' not in os.environ:
-            os.environ['ICE_CONFIG'] = self.test_ice_config
-
-    def run_tests(self):
-        if self.test_pythonpath is not None:
-            sys.path.insert(0, self.test_pythonpath)
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
 
 
 def read(fname):
@@ -102,6 +41,5 @@ setup(
         "rocrate": ["rocrate==0.7.0"],
     },
     python_requires='>=3.8',
-    cmdclass={'test': PyTest},
-    tests_require=['pytest', 'restview', 'mox3'],
+
 )


### PR DESCRIPTION
Using the newer `pytest` interface instead of `python setup.py test`, which is not supported by newer setuptools versions.