### PR TITLE
dealing with empty `image.name` returned by `showinf` in `prepare` (also updating dependencies)

### DIFF
--- a/.omeroci/py-setup
+++ b/.omeroci/py-setup
@@ -19,7 +19,7 @@ conda init
 conda create -n omero python=3.9
 conda activate omero
 pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl
-conda install -c bioconda bftools 
+conda install -y -c bioconda bftools 
 pip install pytest restview mox3
 
 cd $TARGET

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/TheJacksonLaboratory/omero-cli-transfer",
     install_requires=[
-        'ezomero>=2.1.0, <3.0.0',
+        'ezomero>=3.0.0, <4.0.0',
         'ome-types==0.5.1.post1'
     ],
     extras_require={
-        "rocrate": ["rocrate==0.7.0"],
+        "rocrate": ["rocrate>=0.7.0, <1.0.0"],
     },
     python_requires='>=3.8',
 

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -613,7 +613,7 @@ def parse_showinf(text, counter_imgs, counter_plates, counter_ann,
         img_ref[image.id] = img_id_str
         pix = create_empty_pixels(image, img_id)
         if len(ome.images) > 1:  # differentiating names
-            if image.name == "":
+            if not (image.name and image.name.isspace()):
                 image_name = "0"
             else:
                 image_name = image.name
@@ -621,7 +621,11 @@ def parse_showinf(text, counter_imgs, counter_plates, counter_ann,
             img = Image(id=img_id_str, name=filename + " [" + image_name + "]",
                         pixels=pix)
         else:
-            img = Image(id=img_id_str, name=image.name, pixels=pix)
+            if not (image.name and image.name.isspace()):
+                image_name = os.path.split(target)[1]
+            else:
+                image_name = image.name
+            img = Image(id=img_id_str, name=image_name, pixels=pix)
         img_id += 1
         xml = create_path_xml(target)
         ns = 'openmicroscopy.org/cli/transfer'

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -613,7 +613,7 @@ def parse_showinf(text, counter_imgs, counter_plates, counter_ann,
         img_ref[image.id] = img_id_str
         pix = create_empty_pixels(image, img_id)
         if len(ome.images) > 1:  # differentiating names
-            if not (image.name and image.name.isspace()):
+            if not (image.name and not (image.name.isspace())):
                 image_name = "0"
             else:
                 image_name = image.name
@@ -621,7 +621,7 @@ def parse_showinf(text, counter_imgs, counter_plates, counter_ann,
             img = Image(id=img_id_str, name=filename + " [" + image_name + "]",
                         pixels=pix)
         else:
-            if not (image.name and image.name.isspace()):
+            if not (image.name and not (image.name.isspace())):
                 image_name = os.path.split(target)[1]
             else:
                 image_name = image.name


### PR DESCRIPTION
This addresses #87 , where a `Name` attribute wouldn't be set for a single-image `prepare` target when `showinf` returned an empty name string. New behavior is using the filename as image name.

edit: also sneaked in an update to dependencies.