### PR TITLE
updating deps, removing gateway requirement for prepare

### DIFF
--- a/.omeroci/cli-build
+++ b/.omeroci/cli-build
@@ -18,7 +18,7 @@ export JAVA_LD_LIBRARY_PATH="$JAVA_HOME/lib/:$JAVA_HOME/lib/server"
 export CONDA_BACKUP_JAVA_HOME=$JAVA_HOME
 export CONDA_BACKUP_JAVA_LD_LIBRARY_PATH=$JAVA_LD_LIBRARY_PATH
 
-source /tmp/miniconda/bin/activate
+source /tmp/miniforge/bin/activate
 conda init
 conda activate omero
 
@@ -26,7 +26,7 @@ export OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
 export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
 omero $PLUGIN -h
 if [[ $BIN_ACCESS =~ "+plate" ]]; then
-    pytest -v -m "not limit_plate"
+    pytest -v -m "not limit_plate" test/integration/test_prepare.py
 else
     pytest -v -m limit_plate
 fi

--- a/.omeroci/cli-build
+++ b/.omeroci/cli-build
@@ -26,7 +26,7 @@ export OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
 export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
 omero $PLUGIN -h
 if [[ $BIN_ACCESS =~ "+plate" ]]; then
-    pytest -v -m "not limit_plate" test/integration/test_prepare.py
+    pytest -v -m "not limit_plate"
 else
     pytest -v -m limit_plate
 fi

--- a/.omeroci/py-setup
+++ b/.omeroci/py-setup
@@ -12,14 +12,14 @@ export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:/bin/java::")
 export JAVA_LD_LIBRARY_PATH="$JAVA_HOME/lib/:$JAVA_HOME/lib/server"
 export CONDA_BACKUP_JAVA_HOME=$JAVA_HOME
 export CONDA_BACKUP_JAVA_LD_LIBRARY_PATH=$JAVA_LD_LIBRARY_PATH
-wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-sh Miniconda3-latest-Linux-x86_64.sh -b -p /tmp/miniconda
-source /tmp/miniconda/bin/activate
+wget --quiet https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+sh Miniforge3-Linux-x86_64.sh -b -p /tmp/miniforge
+source /tmp/miniforge/bin/activate
 conda init
 conda create -n omero python=3.9
 conda activate omero
 pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl
-conda install -y -c bioconda bftools 
+conda install -y -c ome bftools 
 pip install pytest restview mox3
 
 cd $TARGET

--- a/.omeroci/py-setup
+++ b/.omeroci/py-setup
@@ -16,9 +16,9 @@ wget --quiet https://github.com/conda-forge/miniforge/releases/latest/download/M
 sh Miniforge3-Linux-x86_64.sh -b -p /tmp/miniforge
 source /tmp/miniforge/bin/activate
 conda init
-conda create -n omero python=3.9
+conda create -n omero python=3.11
 conda activate omero
-pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl
+pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
 conda install -y -c ome bftools 
 pip install pytest restview mox3
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     url="https://github.com/TheJacksonLaboratory/omero-cli-transfer",
     install_requires=[
         'ezomero>=3.1.0, <4.0.0',
-        'ome-types>=0.5.3, <0.6.0'
+        'ome-types>=0.6.0, <0.7.0'
     ],
     extras_require={
         "rocrate": ["rocrate>=0.7.0, <1.0.0"],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=['', 'omero.plugins'],
     package_dir={"": "src"},
     name="omero-cli-transfer",
-    version='1.1.0',
+    version='1.1.1',
     maintainer="Erick Ratamero",
     maintainer_email="erick.ratamero@jax.org",
     description=("A set of utilities for exporting a transfer"
@@ -34,8 +34,8 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/TheJacksonLaboratory/omero-cli-transfer",
     install_requires=[
-        'ezomero>=3.0.0, <4.0.0',
-        'ome-types==0.5.1.post1'
+        'ezomero>=3.1.0, <4.0.0',
+        'ome-types>=0.5.3, <0.6.0'
     ],
     extras_require={
         "rocrate": ["rocrate>=0.7.0, <1.0.0"],

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,11 @@ setup(
     url="https://github.com/TheJacksonLaboratory/omero-cli-transfer",
     install_requires=[
         'ezomero>=3.1.0, <4.0.0',
-        'ome-types>=0.6.0, <0.7.0'
+        'ome-types>=0.6.1, <0.7.0'
     ],
     extras_require={
         "rocrate": ["rocrate>=0.7.0, <1.0.0"],
     },
-    python_requires='>=3.8',
+    python_requires='>=3.9',
 
 )

--- a/src/generate_omero_objects.py
+++ b/src/generate_omero_objects.py
@@ -316,9 +316,9 @@ def create_plate_map(ome: OME, img_map: dict, conn: BlitzGateway
     newome = copy.deepcopy(ome)
     plate_map = {}
     map_ref_ids = []
-    for plate in ome.plates:
+    for plate in newome.plates:
         ann_ids = [i.id for i in plate.annotation_refs]
-        for ann in ome.structured_annotations:
+        for ann in newome.structured_annotations:
             if (ann.id in ann_ids and
                     isinstance(ann, XMLAnnotation)):
                 tree = ETree.fromstring(to_xml(ann.value,

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -533,6 +533,7 @@ def create_objects(folder, filelist):
             if img not in (targets):
                 continue
             img_path = os.path.join(os.getcwd(), folder, img)
+            print(f"checking {img_path} for OMERO targets...")
             cmd = ["omero", 'import', '-f', img_path, "\n"]
             res = cli.popen(cmd, stdout=PIPE, stderr=DEVNULL)
             std = res.communicate()
@@ -1007,8 +1008,7 @@ def populate_xml(datatype: str, id: int, filepath: str, conn: BlitzGateway,
     return ome, path_id_dict
 
 
-def populate_xml_folder(folder: str, filelist: bool, conn: BlitzGateway,
-                        session: str) -> Tuple[OME, dict]:
+def populate_xml_folder(folder: str, filelist: bool) -> Tuple[OME, dict]:
     ome = OME()
     images, plates, annotations = create_objects(folder, filelist)
     ome.images = images

--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -31,7 +31,7 @@ from subprocess import PIPE, DEVNULL
 from generate_omero_objects import get_server_path
 import xml.etree.cElementTree as ETree
 from os import PathLike
-import pkg_resources
+import importlib
 import ezomero
 import os
 import csv
@@ -480,7 +480,7 @@ def create_provenance_metadata(conn: BlitzGateway, img_id: int,
     if not metadata:
         return None, None
     software = "omero-cli-transfer"
-    version = pkg_resources.get_distribution(software).version
+    version = importlib.metadata.version(software)
     date_time = datetime.now().strftime("%d/%m/%Y, %H:%M:%S")
     ns = 'openmicroscopy.org/cli/transfer'
     curr_user = conn.getUser().getName()
@@ -672,7 +672,7 @@ def create_path_xml(target):
 
 def create_prepare_metadata(ann_id):
     software = "omero-cli-transfer"
-    version = pkg_resources.get_distribution(software).version
+    version = importlib.metadata.version(software)
     date_time = datetime.now().strftime("%d/%m/%Y, %H:%M:%S")
     ns = 'openmicroscopy.org/cli/transfer/prepare'
     md_dict: Dict[str, Any] = {}
@@ -1115,7 +1115,7 @@ def populate_figures(ome: OME, conn: BlitzGateway, filepath: str):
                                            binary_file=binaryfile)
             filepath_ann, ref = create_figure_annotations(f.id)
             ome.structured_annotations.append(filepath_ann)
-            f.annotation_ref.append(ref)
+            f.annotation_refs.append(ref)
             ome.structured_annotations.append(f)
         else:
             os.remove(filepath)

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -563,16 +563,16 @@ class TransferControl(GraphControl):
                 are located
               image_filenames_mapping: dict that maps image ids to filenames
             """
-            from pkg_resources import iter_entry_points
-            entry_points = []
-            for p in iter_entry_points(group="omero_cli_transfer.pack.plugin"):
+            from importlib.metadata import entry_points
+            entrypoints = []
+            for p in entry_points(group="omero_cli_transfer.pack.plugin"):
                 if p.name == args.plugin:
-                    entry_points.append(p.load())
-            if len(entry_points) == 0:
+                    entrypoints.append(p.load())
+            if len(entrypoints) == 0:
                 raise ValueError(f"Pack plugin {args.plugin} not found")
             else:
-                assert len(entry_points) == 1
-                pack_plugin_func = entry_points[0]
+                assert len(entrypoints) == 1
+                pack_plugin_func = entrypoints[0]
                 pack_plugin_func(
                     ome_object=obj,
                     destination_path=Path(tar_path),

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -308,7 +308,6 @@ class TransferControl(GraphControl):
         """ Implements the 'unpack' command """
         self.__unpack(args)
 
-    @gateway_required
     def prepare(self, args):
         """ Implements the 'prepare' command """
         self.__prepare(args)
@@ -795,8 +794,7 @@ class TransferControl(GraphControl):
         return imgmap
 
     def __prepare(self, args):
-        populate_xml_folder(args.folder, args.filelist, self.gateway,
-                            self.session)
+        populate_xml_folder(args.folder, args.filelist)
         return
 
 

--- a/test/data/prepare/transfer.xml
+++ b/test/data/prepare/transfer.xml
@@ -5,80 +5,108 @@
         <ImageRef ID="Image:1"/>
       </WellSample>
     </Well>
-    <AnnotationRef ID="Annotation:-302109755386744031474663137255099440619"/>
+    <AnnotationRef ID="Annotation:3"/>
   </Plate>
   <Image ID="Image:1" Name="default-plate">
     <Pixels ID="Pixels:1" DimensionOrder="XYZCT" Type="uint8" SizeX="512" SizeY="512" SizeZ="1" SizeC="1" SizeT="1">
       <MetadataOnly/>
     </Pixels>
-    <AnnotationRef ID="Annotation:-55040966795353415047517454760603713654"/>
-    <AnnotationRef ID="Annotation:-60189972287065119682949125532632336000"/>
+    <AnnotationRef ID="Annotation:1"/>
+    <AnnotationRef ID="Annotation:2"/>
   </Image>
   <Image ID="Image:2" Name="test_pyramid.tiff">
     <Pixels ID="Pixels:2" DimensionOrder="XYCZT" Type="uint8" SizeX="16" SizeY="16" SizeZ="1" SizeC="1" SizeT="1">
       <MetadataOnly/>
     </Pixels>
-    <AnnotationRef ID="Annotation:-124740294806861926766131915590778711100"/>
-    <AnnotationRef ID="Annotation:-235134109673596436144013343504048608878"/>
+    <AnnotationRef ID="Annotation:4"/>
+    <AnnotationRef ID="Annotation:5"/>
   </Image>
   <Image ID="Image:3" Name="vsi-ets-test-jpg2k.vsi [001 C405, C488]">
     <Pixels ID="Pixels:3" DimensionOrder="XYCZT" Type="uint16" SizeX="1645" SizeY="1682" SizeZ="11" SizeC="2" SizeT="1">
       <MetadataOnly/>
     </Pixels>
-    <AnnotationRef ID="Annotation:-259343186022718704856275667016466761689"/>
-    <AnnotationRef ID="Annotation:-224780865139240311027116801634970628041"/>
+    <AnnotationRef ID="Annotation:6"/>
+    <AnnotationRef ID="Annotation:7"/>
   </Image>
   <Image ID="Image:4" Name="vsi-ets-test-jpg2k.vsi [macro image]">
     <Pixels ID="Pixels:4" DimensionOrder="XYCZT" Type="uint8" SizeX="501" SizeY="512" SizeZ="1" SizeC="3" SizeT="1">
       <MetadataOnly/>
     </Pixels>
-    <AnnotationRef ID="Annotation:-63003149123325712739521864873102528314"/>
-    <AnnotationRef ID="Annotation:-180673318620852740990473970358731429779"/>
+    <AnnotationRef ID="Annotation:8"/>
+    <AnnotationRef ID="Annotation:9"/>
   </Image>
   <StructuredAnnotations>
-    <CommentAnnotation ID="Annotation:-55040966795353415047517454760603713654" Namespace="Image:1">
-      <Value>default-plate&amp;plates=1.fake</Value>
-    </CommentAnnotation>
-    <MapAnnotation ID="Annotation:-60189972287065119682949125532632336000" Namespace="openmicroscopy.org/cli/transfer/prepare">
+    <XMLAnnotation ID="Annotation:1" Namespace="openmicroscopy.org/cli/transfer">
       <Value>
-        <M K="software">omero-cli-transfer</M>
-        <M K="version">0.6.0</M>
-        <M K="packing_timestamp">08/08/2023, 13:51:49</M>
+        <CLITransferServerPath xsi:schemaLocation="https://raw.githubusercontent.com/ome/omero-cli-transfer/main/schemas/serverpath.xsd">
+          <Path>default-plate&amp;plates=1.fake</Path>
+        </CLITransferServerPath>
       </Value>
-    </MapAnnotation>
-    <CommentAnnotation ID="Annotation:-302109755386744031474663137255099440619" Namespace="Plate:1">
-      <Value>default-plate&amp;plates=1.fake</Value>
-    </CommentAnnotation>
-    <CommentAnnotation ID="Annotation:-124740294806861926766131915590778711100" Namespace="Image:2">
-      <Value>test_pyramid.ome.tif</Value>
-    </CommentAnnotation>
-    <MapAnnotation ID="Annotation:-235134109673596436144013343504048608878" Namespace="openmicroscopy.org/cli/transfer/prepare">
+    </XMLAnnotation>
+    <XMLAnnotation ID="Annotation:2" Namespace="openmicroscopy.org/cli/transfer/prepare">
       <Value>
-        <M K="software">omero-cli-transfer</M>
-        <M K="version">0.6.0</M>
-        <M K="packing_timestamp">08/08/2023, 13:51:51</M>
+        <CLITransferMetadata xsi:schemaLocation="https://raw.githubusercontent.com/ome/omero-cli-transfer/main/schemas/preparemetadata.xsd">
+          <software>omero-cli-transfer</software>
+          <version>1.1.1</version>
+          <packing_timestamp>19/02/2025, 14:38:13</packing_timestamp>
+        </CLITransferMetadata>
       </Value>
-    </MapAnnotation>
-    <CommentAnnotation ID="Annotation:-259343186022718704856275667016466761689" Namespace="Image:3">
-      <Value>vsi-ets-test-jpg2k.vsi</Value>
-    </CommentAnnotation>
-    <MapAnnotation ID="Annotation:-224780865139240311027116801634970628041" Namespace="openmicroscopy.org/cli/transfer/prepare">
+    </XMLAnnotation>
+    <XMLAnnotation ID="Annotation:3" Namespace="openmicroscopy.org/cli/transfer">
       <Value>
-        <M K="software">omero-cli-transfer</M>
-        <M K="version">0.6.0</M>
-        <M K="packing_timestamp">08/08/2023, 13:51:53</M>
+        <CLITransferServerPath xsi:schemaLocation="https://raw.githubusercontent.com/ome/omero-cli-transfer/main/schemas/serverpath.xsd">
+          <Path>default-plate&amp;plates=1.fake</Path>
+        </CLITransferServerPath>
       </Value>
-    </MapAnnotation>
-    <CommentAnnotation ID="Annotation:-63003149123325712739521864873102528314" Namespace="Image:4">
-      <Value>vsi-ets-test-jpg2k.vsi</Value>
-    </CommentAnnotation>
-    <MapAnnotation ID="Annotation:-180673318620852740990473970358731429779" Namespace="openmicroscopy.org/cli/transfer/prepare">
+    </XMLAnnotation>
+    <XMLAnnotation ID="Annotation:4" Namespace="openmicroscopy.org/cli/transfer">
       <Value>
-        <M K="software">omero-cli-transfer</M>
-        <M K="version">0.6.0</M>
-        <M K="packing_timestamp">08/08/2023, 13:51:53</M>
+        <CLITransferServerPath xsi:schemaLocation="https://raw.githubusercontent.com/ome/omero-cli-transfer/main/schemas/serverpath.xsd">
+          <Path>test_pyramid.ome.tif</Path>
+        </CLITransferServerPath>
       </Value>
-    </MapAnnotation>
+    </XMLAnnotation>
+    <XMLAnnotation ID="Annotation:5" Namespace="openmicroscopy.org/cli/transfer/prepare">
+      <Value>
+        <CLITransferMetadata xsi:schemaLocation="https://raw.githubusercontent.com/ome/omero-cli-transfer/main/schemas/preparemetadata.xsd">
+          <software>omero-cli-transfer</software>
+          <version>1.1.1</version>
+          <packing_timestamp>19/02/2025, 14:38:15</packing_timestamp>
+        </CLITransferMetadata>
+      </Value>
+    </XMLAnnotation>
+    <XMLAnnotation ID="Annotation:6" Namespace="openmicroscopy.org/cli/transfer">
+      <Value>
+        <CLITransferServerPath xsi:schemaLocation="https://raw.githubusercontent.com/ome/omero-cli-transfer/main/schemas/serverpath.xsd">
+          <Path>vsi-ets-test-jpg2k.vsi</Path>
+        </CLITransferServerPath>
+      </Value>
+    </XMLAnnotation>
+    <XMLAnnotation ID="Annotation:7" Namespace="openmicroscopy.org/cli/transfer/prepare">
+      <Value>
+        <CLITransferMetadata xsi:schemaLocation="https://raw.githubusercontent.com/ome/omero-cli-transfer/main/schemas/preparemetadata.xsd">
+          <software>omero-cli-transfer</software>
+          <version>1.1.1</version>
+          <packing_timestamp>19/02/2025, 14:38:17</packing_timestamp>
+        </CLITransferMetadata>
+      </Value>
+    </XMLAnnotation>
+    <XMLAnnotation ID="Annotation:8" Namespace="openmicroscopy.org/cli/transfer">
+      <Value>
+        <CLITransferServerPath xsi:schemaLocation="https://raw.githubusercontent.com/ome/omero-cli-transfer/main/schemas/serverpath.xsd">
+          <Path>vsi-ets-test-jpg2k.vsi</Path>
+        </CLITransferServerPath>
+      </Value>
+    </XMLAnnotation>
+    <XMLAnnotation ID="Annotation:9" Namespace="openmicroscopy.org/cli/transfer/prepare">
+      <Value>
+        <CLITransferMetadata xsi:schemaLocation="https://raw.githubusercontent.com/ome/omero-cli-transfer/main/schemas/preparemetadata.xsd">
+          <software>omero-cli-transfer</software>
+          <version>1.1.1</version>
+          <packing_timestamp>19/02/2025, 14:38:17</packing_timestamp>
+        </CLITransferMetadata>
+      </Value>
+    </XMLAnnotation>
   </StructuredAnnotations>
 </OME>
 

--- a/test/integration/test_prepare.py
+++ b/test/integration/test_prepare.py
@@ -17,7 +17,6 @@ from ome_types.model.screen import PlateRef
 from ome_types.model.map import M, Map
 from uuid import uuid4
 
-
 import ezomero
 import pytest
 import os
@@ -39,6 +38,7 @@ class TestPrepare(CLITest):
         self.args += ["transfer"]
         self.gw = BlitzGateway(client_obj=self.client)
         self.session = self.client.getSessionId()
+        self.cli.loadplugins()
 
     def delete_all(self):
         pjs = self.gw.getObjects("Project")
@@ -78,6 +78,22 @@ class TestPrepare(CLITest):
         self.args += ["prepare", "./fakefoldername/"]
         with pytest.raises(ValueError):
             self.cli.invoke(self.args, strict=True)
+
+    def test_dummy_prepare(self):
+        folder = Path(TEST_FOLDERS[0])
+        if Path(folder / 'transfer.xml').exists():
+            print('transfer.xml exists! deleting.')
+            os.remove(str(folder / 'transfer.xml'))
+        args = self.args + ["prepare", str(folder)]
+        self.cli.invoke(args, strict=True)
+        assert Path(folder / 'transfer.xml').exists()
+        assert os.path.getsize(str(folder / 'transfer.xml')) > 0
+        args = self.args + ["unpack", "--folder", str(folder)]
+        with pytest.raises(KeyError):
+            self.cli.invoke(args, strict=True)
+        self.delete_all()
+        if Path(folder / 'transfer.xml').exists():
+            os.remove(str(folder / 'transfer.xml'))
 
     @pytest.mark.parametrize('folder', sorted(TEST_FOLDERS))
     def test_prepare_clean(self, folder):


### PR DESCRIPTION
This PR removes the `@gateway_required` decorator from `prepare`, allowing it to be run without a valid session on an OMERO server. (it also updates a few dependencies.)