### PR TITLE
Fix fileannotation download bug

### DIFF
--- a/src/generate_xml.py
+++ b/src/generate_xml.py
@@ -976,7 +976,7 @@ def list_file_ids(ome: OME) -> dict:
             if ann.namespace != "omero.web.figure.json":
                 path = get_server_path(ann.annotation_refs,
                                        ome.structured_annotations)
-            id_list[ann.id] = path
+                id_list[ann.id] = path
     return id_list
 
 


### PR DESCRIPTION
Due to a mis-indented line and a reused variable, sometimes duplicate omero.figure json content is downloaded to a different file's path.