### PR TITLE
Use v1 to avoid issue when publishing

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -26,6 +26,6 @@ jobs:
         python -mpip install build
         python -m build
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.14
+      uses: pypa/gh-action-pypi-publish@v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/upload_to_test_pypi.yml
+++ b/.github/workflows/upload_to_test_pypi.yml
@@ -26,7 +26,7 @@ jobs:
         python -mpip install build
         python -m build
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.14
+      uses: pypa/gh-action-pypi-publish@v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Bumping the action to the release/v1 branch should include the latest stable patches and fix the release to PyPI