### PR TITLE
Use `pyproject.toml` instead of `setup.py`

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -22,6 +22,8 @@ jobs:
       with:
           python-version: '3.9'
     - name: Install Tools
+      env:
+        VERSION: ${{ github.event.release.tag_name }}
       run: |
         python -mpip install build
         python -m build

--- a/.github/workflows/upload_to_test_pypi.yml
+++ b/.github/workflows/upload_to_test_pypi.yml
@@ -22,6 +22,8 @@ jobs:
       with:
           python-version: '3.9'
     - name: Install Tools
+      env:
+        VERSION: ${{ github.event.release.tag_name }}
       run: |
         python -mpip install build
         python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+
+name = "omero-cli-transfer"
+dynamic = ["version"]
+maintainers = [
+    {name = "Erick Ratamero", email = "erick.ratamero@jax.org"}
+    ]
+description = "A set of utilities for exporting a transfer packet from an OMERO server and importing it in a different server. Developed by the Research IT team at The Jackson Laboratory."
+readme = "README.md"
+license = "GPL-2.0"
+dependencies = [
+    "ezomero>=3.1.0, <4.0.0",
+    "ome-types>=0.6.1, <0.7.0"
+    ]
+requires-python = ">=3.9"
+
+[tool.setuptools]
+packages = ["", "omero.plugins"]
+
+[project.optional-dependencies]
+rocrate = ["rocrate>=0.7.0, <1.0.0"]
+
+[project.urls]
+Repository = "https://github.com/TheJacksonLaboratory/omero-cli-transfer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ dependencies = [
     ]
 requires-python = ">=3.9"
 
-[tool.setuptools]
-packages = ["", "omero.plugins"]
-
 [project.optional-dependencies]
 rocrate = ["rocrate>=0.7.0, <1.0.0"]
 

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,13 @@
 #
 # Use is subject to license terms supplied in LICENSE.
 
+import setuptools
 import os
-from setuptools import setup
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+setuptools.setup(
+    version=os.environ.get('VERSION', '0.0.0'),
+)
 
-
-def read(fname):
-    """
-    Utility function to read the README file.
-    :rtype : String
-    """
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -10,30 +10,3 @@ import os
 setuptools.setup(
     version=os.environ.get('VERSION', '0.0.0'),
 )
-
-
-
-setup(
-    packages=['', 'omero.plugins'],
-    package_dir={"": "src"},
-    name="omero-cli-transfer",
-    version='1.2.0',
-    maintainer="Erick Ratamero",
-    maintainer_email="erick.ratamero@jax.org",
-    description=("A set of utilities for exporting a transfer"
-                 " packet from an OMERO server and importing "
-                 "it in a different server. Developed by the "
-                 "Research IT team at The Jackson Laboratory."),
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/TheJacksonLaboratory/omero-cli-transfer",
-    install_requires=[
-        'ezomero>=3.1.0, <4.0.0',
-        'ome-types>=0.6.1, <0.7.0'
-    ],
-    extras_require={
-        "rocrate": ["rocrate>=0.7.0, <1.0.0"],
-    },
-    python_requires='>=3.9',
-
-)


### PR DESCRIPTION
Modernizing the build/install infra by moving everything to a `pyproject.toml` file. Also sets up the PyPI upload actions to use dynamic versioning retrieved from the Github release tags.