### PR TITLE
updated requirements to match pyproject

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ezomero>=2.0.0<3.0.0
-ome-types>=0.5.0<0.6.0
+ezomero>=3.1.0<4.0.0
+ome-types>=0.6.1<0.7.0
 setuptools>=58.0.0


### PR DESCRIPTION
requirements.txt was out of date with actual version requirements for ezomero and ome-types based on the pyproject.toml