### PR TITLE
Adding `pack` option to create uncompressed folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=41", "setuptools-git-versioning>=2.0,<3"]
 build-backend = "setuptools.build_meta"
+
+
+[tool.setuptools-git-versioning]
+enabled = true
 
 [project]
 

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -72,6 +72,10 @@ in `.zip` will generate a (compressed) zip file, a path ending in `.tar` will
 generate a tarball, anything else will be interpreted as a desired output
 folder.
 
+--zip is deprecated and will be ignored - it is still allowed for backwards
+compatibility. If you want a zip file, simply make sure your output has that
+extension.
+
 --figure includes OMERO.Figures; note that this can lead to a performance
 hit and that Figures can reference images that are not included in your pack!
 
@@ -103,7 +107,8 @@ will be written.
 
 Examples:
 omero transfer pack Image:123 transfer_pack.tar
-omero transfer pack --zip Image:123 transfer_pack.zip
+omero transfer pack Image:123 transfer_pack.zip
+omero transfer pack Image:123 folder1/folder2/
 omero transfer pack Dataset:1111 /home/user/new_folder/new_pack.tar
 omero transfer pack 999 tarfile.tar  # equivalent to Project:999
 omero transfer pack 1 transfer_pack.tar --metadata img_id version db_id
@@ -234,6 +239,11 @@ class TransferControl(GraphControl):
         pack.add_argument(
                 "--barchive", help="Pack into a file compliant with Bioimage"
                                    " Archive submission standards",
+                action="store_true")
+        pack.add_argument(
+                "--zip", help="Deprecated option to generate zip files. It "
+                                   "is ignored - just name your output "
+                                   "accordingly.",
                 action="store_true")
         pack.add_argument(
                 "--rocrate", help="Pack into a file compliant with "

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -242,8 +242,8 @@ class TransferControl(GraphControl):
                 action="store_true")
         pack.add_argument(
                 "--zip", help="Deprecated option to generate zip files. It "
-                                   "is ignored - just name your output "
-                                   "accordingly.",
+                              "is ignored - just name your output "
+                              "accordingly.",
                 action="store_true")
         pack.add_argument(
                 "--rocrate", help="Pack into a file compliant with "

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -414,9 +414,13 @@ class TransferControl(GraphControl):
         if ext == ".tar":
             logger.info("Creating tar file...")
             shutil.make_archive(basepath, 'tar', folder)
+            logger.info("Cleaning up...")
+            shutil.rmtree(folder)
         elif ext == ".zip":
             logger.info("Creating zip file...")
             shutil.make_archive(basepath, 'zip', folder)
+            logger.info("Cleaning up...")
+            shutil.rmtree(folder)
         else:
             logger.info("Moving to destination folder...")
             shutil.move(folder, dest_path)
@@ -593,8 +597,6 @@ class TransferControl(GraphControl):
                     conn=self.gateway)
         elif args.binaries == "all":
             self._package_files(tar_path, folder)
-            logger.info("Cleaning up...")
-            shutil.rmtree(folder)
         return
 
     def __unpack(self, args):

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -144,7 +144,7 @@ class TestTransfer(CLITest):
         self.cli.invoke(args, strict=True)
         assert os.path.exists(str(tmpdir / 'test.tar'))
         assert os.path.getsize(str(tmpdir / 'test.tar')) > 0
-        args = self.args + ["pack", target, "--zip", str(tmpdir / 'test.zip')]
+        args = self.args + ["pack", target, str(tmpdir / 'test.zip')]
         self.cli.invoke(args, strict=True)
         assert os.path.exists(str(tmpdir / 'test.zip'))
         assert os.path.getsize(str(tmpdir / 'test.zip')) > 0
@@ -467,7 +467,7 @@ class TestTransfer(CLITest):
             args = self.args + ["pack", target, str(tmpdir / name)]
         else:
             name = 'test.zip'
-            args = self.args + ["pack", target, "--zip", str(tmpdir / name)]
+            args = self.args + ["pack", target, str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()
         args = self.args + ["unpack", str(tmpdir / name)]
@@ -491,7 +491,7 @@ class TestTransfer(CLITest):
                 args = self.args + ["pack", target, str(tmpdir / name)]
             else:
                 name = 'test.zip'
-                args = self.args + ["pack", target, "--zip",
+                args = self.args + ["pack", target,
                                     str(tmpdir / name)]
             self.cli.invoke(args, strict=True)
             self.delete_all()
@@ -510,7 +510,7 @@ class TestTransfer(CLITest):
                 args = self.args + ["pack", target, str(tmpdir / name)]
             else:
                 name = 'test.zip'
-                args = self.args + ["pack", target, "--zip",
+                args = self.args + ["pack", target,
                                     str(tmpdir / name)]
             self.cli.invoke(args, strict=True)
             self.delete_all()
@@ -535,7 +535,7 @@ class TestTransfer(CLITest):
             args = self.args + ["pack", target, str(tmpdir / name)]
         else:
             name = 'test.zip'
-            args = self.args + ["pack", target, "--zip",
+            args = self.args + ["pack", target,
                                 str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()
@@ -554,7 +554,7 @@ class TestTransfer(CLITest):
             args = self.args + ["pack", target, str(tmpdir / name)]
         else:
             name = 'test.zip'
-            args = self.args + ["pack", target, "--zip",
+            args = self.args + ["pack", target,
                                 str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()
@@ -579,7 +579,7 @@ class TestTransfer(CLITest):
             args = self.args + ["pack", target, str(tmpdir / name)]
         else:
             name = 'test.zip'
-            args = self.args + ["pack", target, "--zip",
+            args = self.args + ["pack", target,
                                 str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()
@@ -599,7 +599,7 @@ class TestTransfer(CLITest):
             args = self.args + ["pack", target, str(tmpdir / name)]
         else:
             name = 'test.zip'
-            args = self.args + ["pack", target, "--zip",
+            args = self.args + ["pack", target,
                                 str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()
@@ -623,7 +623,7 @@ class TestTransfer(CLITest):
             args = self.args + ["pack", target, str(tmpdir / name)]
         else:
             name = 'test.zip'
-            args = self.args + ["pack", target, "--zip",
+            args = self.args + ["pack", target,
                                 str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()
@@ -642,7 +642,7 @@ class TestTransfer(CLITest):
             args = self.args + ["pack", target, str(tmpdir / name)]
         else:
             name = 'test.zip'
-            args = self.args + ["pack", target, "--zip",
+            args = self.args + ["pack", target,
                                 str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()
@@ -666,7 +666,7 @@ class TestTransfer(CLITest):
             args = self.args + ["pack", target, str(tmpdir / name)]
         else:
             name = 'test.zip'
-            args = self.args + ["pack", target, "--zip",
+            args = self.args + ["pack", target,
                                 str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()
@@ -685,7 +685,7 @@ class TestTransfer(CLITest):
             args = self.args + ["pack", target, str(tmpdir / name)]
         else:
             name = 'test.zip'
-            args = self.args + ["pack", target, "--zip",
+            args = self.args + ["pack", target,
                                 str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()

--- a/test/integration/test_transfer.py
+++ b/test/integration/test_transfer.py
@@ -148,6 +148,10 @@ class TestTransfer(CLITest):
         self.cli.invoke(args, strict=True)
         assert os.path.exists(str(tmpdir / 'test.zip'))
         assert os.path.getsize(str(tmpdir / 'test.zip')) > 0
+        args = self.args + ["pack", target, str(tmpdir / 'test_folder')]
+        self.cli.invoke(args, strict=True)
+        assert os.path.exists(str(tmpdir / 'test_folder'))
+        assert any(os.listdir(str(tmpdir / 'test_folder')))
         args = self.args + ["pack", target, "--barchive",
                             str(tmpdir / 'testba.tar')]
         if target_name == "datasetid" or target_name == "projectid" \
@@ -453,7 +457,7 @@ class TestTransfer(CLITest):
         assert len(pl_ids) == 4
         self.delete_all()
 
-    @pytest.mark.parametrize('packing', ["tar", "zip"])
+    @pytest.mark.parametrize('packing', ["tar", "zip", "folder"])
     @pytest.mark.parametrize('target_name', sorted(SUPPORTED))
     def test_pack_unpack(self, target_name, packing, tmpdir):
         if target_name == "datasetid" or target_name == "projectid" or\
@@ -465,12 +469,18 @@ class TestTransfer(CLITest):
         if packing == "tar":
             name = 'test.tar'
             args = self.args + ["pack", target, str(tmpdir / name)]
-        else:
+        elif packing == "zip":
             name = 'test.zip'
+            args = self.args + ["pack", target, str(tmpdir / name)]
+        else:
+            name = 'test_folder'
             args = self.args + ["pack", target, str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.delete_all()
-        args = self.args + ["unpack", str(tmpdir / name)]
+        if packing == "folder":
+            args = self.args + ["unpack", "--folder", str(tmpdir / name)]
+        else:
+            args = self.args + ["unpack", str(tmpdir / name)]
         self.cli.invoke(args, strict=True)
         self.run_asserts(target_name)
         self.delete_all()


### PR DESCRIPTION
This PR does two things:
- it revamps how we decide what kind of `pack` to generate. Instead of explicitly having to pass a `--zip` flag, for example, we now detect the extension of the desired output. `.tar` and `.zip` generate these file formats.
- it allows for generating `pack`s as uncompressed folders. Any output not ending in `.tar` or `.zip` will be considered as a folder, and the resulting `pack` will be inside that folder. 

It includes appropriate tests (`pack` into folders, then use that for a folder `unpack`).