### PR TITLE
Issue with FileAnnotations using simple transfer

### DIFF
--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -28,7 +28,7 @@ from generate_xml import populate_xml_folder
 from generate_omero_objects import populate_omero, get_server_path
 
 import ezomero
-from ome_types.model import XMLAnnotation, OME
+from ome_types.model import XMLAnnotation, FileAnnotation, MapAnnotation, ListAnnotation, OME
 from ome_types import from_xml, to_xml
 from omero.sys import Parameters
 from omero.rtypes import rstring
@@ -454,8 +454,8 @@ class TransferControl(GraphControl):
                                  ) -> OME:
         newome = copy.deepcopy(ome)
         for ann in ome.structured_annotations:
-            if isinstance(ann, (FileAnnotation, XMLAnnotation)):
-               continue
+            if isinstance(ann, (FileAnnotation, XMLAnnotation, MapAnnotation, ListAnnotation)):
+                continue
             if isinstance(ann.value, str) and\
                ann.value.startswith("pixel_images"):
                 for img in newome.images:

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -28,7 +28,13 @@ from generate_xml import populate_xml_folder
 from generate_omero_objects import populate_omero, get_server_path
 
 import ezomero
-from ome_types.model import XMLAnnotation, FileAnnotation, MapAnnotation, ListAnnotation, OME
+from ome_types.model import (
+    XMLAnnotation,
+    FileAnnotation,
+    MapAnnotation,
+    ListAnnotation,
+    OME
+)
 from ome_types import from_xml, to_xml
 from omero.sys import Parameters
 from omero.rtypes import rstring
@@ -454,7 +460,8 @@ class TransferControl(GraphControl):
                                  ) -> OME:
         newome = copy.deepcopy(ome)
         for ann in ome.structured_annotations:
-            if isinstance(ann, (FileAnnotation, XMLAnnotation, MapAnnotation, ListAnnotation)):
+            if isinstance(ann, (FileAnnotation, XMLAnnotation,
+                                MapAnnotation, ListAnnotation)):
                 continue
             if isinstance(ann.value, str) and\
                ann.value.startswith("pixel_images"):

--- a/src/omero_cli_transfer.py
+++ b/src/omero_cli_transfer.py
@@ -454,6 +454,8 @@ class TransferControl(GraphControl):
                                  ) -> OME:
         newome = copy.deepcopy(ome)
         for ann in ome.structured_annotations:
+            if isinstance(ann, (FileAnnotation, XMLAnnotation)):
+               continue
             if isinstance(ann.value, str) and\
                ann.value.startswith("pixel_images"):
                 for img in newome.images:


### PR DESCRIPTION
When transferring some data from OMERO using omero-cli-transfer with the `--simple` flag I got the following error:

```
....
  File "D:\OMERO\omero_transfer\.pixi\envs\default\Lib\site-packages\omero_cli_transfer.py", line 199, in _wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\OMERO\omero_transfer\.pixi\envs\default\Lib\site-packages\omero_cli_transfer.py", line 319, in pack
    self.__pack(args)
  File "D:\OMERO\omero_transfer\.pixi\envs\default\Lib\site-packages\omero_cli_transfer.py", line 570, in __pack
    self._fix_pixels_image_simple(ome, folder, md_fp)
  File "D:\OMERO\omero_transfer\.pixi\envs\default\Lib\site-packages\omero_cli_transfer.py", line 456, in _fix_pixels_image_simple
    if isinstance(ann.value, str) and\
                  ^^^^^^^^^
  File "D:\OMERO\omero_transfer\.pixi\envs\default\Lib\site-packages\ome_types\_mixins\_base_type.py", line 152, in __getattr__
    return super().__getattr__(key)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\OMERO\omero_transfer\.pixi\envs\default\Lib\site-packages\pydantic\main.py", line 1026, in __getattr__
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
AttributeError: 'FileAnnotation' object has no attribute 'value'
```

It seems that the issue is that the function ` _fix_pixels_image_simple` assumes all annotations have a value attribute but apparently not all annotation types do. 
With this PR I added a check for the annotation type first. Please adjust if necessary.